### PR TITLE
Do not hardcode ~/.local/share, use [~/.config]/unvanquished/updater.conf path, etc.

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,9 +11,11 @@
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setOrganizationName("Unvanquished Development");
+    // The two following variables set the config file path
+    // to: ~/.config/unvanquished/updater.conf
+    QCoreApplication::setApplicationName("updater");
+    QCoreApplication::setOrganizationName("unvanquished");
     QCoreApplication::setOrganizationDomain("unvanquished.net");
-    QCoreApplication::setApplicationName("Unvanquished Updater");
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication app(argc, argv);
     app.setWindowIcon(QIcon(":resources/updater.png"));

--- a/unix.cpp
+++ b/unix.cpp
@@ -5,6 +5,7 @@
 #include <QDebug>
 #include <QCoreApplication>
 #include <QProcess>
+#include <QStandardPaths>
 
 namespace Sys {
 QString archiveName(void)
@@ -14,7 +15,11 @@ QString archiveName(void)
 
 QString defaultInstallPath(void)
 {
-    return QDir::homePath() + "/.local/share/Unvanquished";
+    // Does not use QStandardPaths::AppDataLocation because
+    // it returns "~/.local/share/unvanquished/updater"
+    // and we want "~/.local/share/unvanquished/base"
+    // game itself puts stuff in "~/.local/share/unvanquished"
+    return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/unvanquished/base";
 }
 
 QString executableName(void)
@@ -32,7 +37,7 @@ bool install(void)
     }
     QString desktopStr = QString(desktopFile.readAll().data())
         .arg(settings.installPath());
-    QFile outputFile(QDir::homePath() + "/.local/share/applications/unvanquished.desktop");
+    QFile outputFile(QStandardPaths::writableLocation(QStandardPaths::ApplicationsLocation) + "/unvanquished.desktop");
     if (!outputFile.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
         desktopFile.close();
         return false;
@@ -41,7 +46,7 @@ bool install(void)
     outputFile.close();
 
     // install icon
-    QString iconDir = QDir::homePath() + "/.local/share/icons/hicolor/128x128/apps/";
+    QString iconDir = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/icons/hicolor/128x128/apps/";
     QDir dir(iconDir);
     if (!dir.exists()) {
         if (!dir.mkpath(dir.path())) {


### PR DESCRIPTION
Do not hardcode ~/.local/share

- it can be overriden by $XDG_DATA_HOME
- use QStandardPaths
- use ~/.local/share/unvanquished/base instead of ~/.local/share/Unvanquished
- updater config path is now ~/.config/unvanquished/updater.conf

Do not merge it so fast, because the default directories can be modified
See https://github.com/Unvanquished/Unvanquished/issues/730#issuecomment-312753551