### PR TITLE
use an explicit os-arch naming scheme for zip shipping binaries

### DIFF
--- a/osx.cpp
+++ b/osx.cpp
@@ -33,7 +33,7 @@ QString extractAppPath(const QString& path) {
 namespace Sys {
 QString archiveName()
 {
-    return "mac.zip";
+    return "macos-amd64.zip";
 }
 
 QString defaultInstallPath()

--- a/unix.cpp
+++ b/unix.cpp
@@ -11,7 +11,7 @@
 namespace Sys {
 QString archiveName()
 {
-    return "linux64.zip";
+    return "linux-amd64.zip";
 }
 
 void migrateHomePath()

--- a/win.cpp
+++ b/win.cpp
@@ -110,9 +110,9 @@ bool IsWow64()
 QString archiveName()
 {
     if (IsWow64()) {
-        return "win64.zip";
+        return "windows-amd64.zip";
     } else {
-        return "win32.zip";
+        return "windows-i686.zip";
     }
 }
 


### PR DESCRIPTION
and be ready for `haiku-ppc`