### PR TITLE
drop stripHttpsIfWin, server does the job

### DIFF
--- a/News.qml
+++ b/News.qml
@@ -14,15 +14,6 @@ Item {
         bottomMargin: 10
     }
 
-    function stripHttpsIfWin(url) {
-
-        var httpsPrefix = 'https://'
-        if (Qt.platform.os === 'windows' && url.startsWith(httpsPrefix)) {
-            return 'http://' + url.substring(httpsPrefix.length);
-        }
-        return url;
-    }
-
     function fetchNews() {
         var news = new XMLHttpRequest();
         news.onreadystatechange = function() {
@@ -33,7 +24,7 @@ Item {
                     var object = component.createObject(swipe);
                     var post = newsObj['posts'][i];
                     if (post['thumbnail_images']) {
-                        object.source = Qt.resolvedUrl(stripHttpsIfWin(post['thumbnail_images']['medium']['url']));
+                        object.source = Qt.resolvedUrl(post['thumbnail_images']['medium']['url']);
                     }
                     object.cardTitle = post['title_plain'];
                     object.summary = post['excerpt'];


### PR DESCRIPTION
server already rewrites content to fix urls and does more than just rewriting protocol, it also takes care of `www` prefix, see https://github.com/Unvanquished/updater/issues/41#issuecomment-521851956 for some information about how it was done server side

Thanks to some nginx magic code, when the news json is fetched the `http://www.unvanquished.net` way, all url in json are rewritten the `http://www.unvanquished.net`, and when the news json is fetched the `https://unvanquished.net`, all url in json are rewritten the `https://unvanquished.net` way.

This way the server ensure old updater still works, and we can publish https aware updater that does not use `www` prefix in the future. We don't have to write any workaround in the updater code itself.