### PR TITLE
print logs when fetching version

### DIFF
--- a/currentversionfetcher.cpp
+++ b/currentversionfetcher.cpp
@@ -22,12 +22,14 @@ void CurrentVersionFetcher::reply(QNetworkReply* reply)
     QString game;
     QString updater;
     if (reply->error() != QNetworkReply::NoError) {
+        qDebug() << "CurrentVersionFetcher: network error";
         emit onCurrentVersions(updater, game);
         return;
     }
     QJsonParseError error;
     QJsonDocument json = QJsonDocument::fromJson(reply->readAll(), &error);
     if (error.error != QJsonParseError::NoError) {
+        qDebug() << "CurrentVersionFetcher: JSON parsing error";
         emit onCurrentVersions(updater, game);
         return;
     }
@@ -35,10 +37,17 @@ void CurrentVersionFetcher::reply(QNetworkReply* reply)
     if (value != QJsonValue::Undefined) {
         updater = value.toString();
     }
+    else {
+        qDebug() << "CurrentVersionFetcher: undefined “updater” value";
+    }
     value = json.object().value("unvanquished");
     if (value != QJsonValue::Undefined) {
         game = value.toString();
     }
+    else {
+        qDebug() << "CurrentVersionFetcher: undefined “unvanquished” value";
+    }
+    qDebug() << "CurrentVersionFetcher: fetched versions: updater =" << updater << "game =" << game;
     emit onCurrentVersions(updater, game);
 }
 


### PR DESCRIPTION
I noticed [dl.unvanquished.net/versions.json](https://dl.unvanquished.net/versions.json/versions.json) was malformed (I was probably the one breaking it) but the updater did not complain about that at all…