### PR TITLE
Rewrite Windows Docker file

### DIFF
--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-# All packages are MXE deps except dos2unix: https://mxe.cc/#requirements
+# All packages are MXE deps: https://mxe.cc/#requirements
 RUN apt-get update && apt-get install -y \
     autoconf \
     automake \
@@ -31,8 +31,7 @@ RUN apt-get update && apt-get install -y \
     sed \
     unzip \
     wget \
-    xz-utils \
-    dos2unix
+    xz-utils
 
 #########################################
 # Build Qt (and cross-compiler) via MXE #
@@ -49,8 +48,6 @@ ENV PATH=$PATH:/mxe/usr/bin
 # Build aria2 #
 ###############
 COPY aria2 /updater2/aria2
-# Let it build when checked out on a Windows host
-RUN find /updater2/aria2 -type f -print0 | xargs -0 dos2unix
 WORKDIR /updater2/aria2
 RUN autoreconf -i && ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-libz --without-libcares --enable-static=yes ARIA2_STATIC=yes --without-libssh2 --disable-websocket --host i686-w64-mingw32.static && make -j`nproc`
 

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -1,9 +1,62 @@
-FROM dolcetriade/qt5-windows-static:5.8.0
-RUN pacman -Sy --noconfirm git
-COPY . /updater2
+FROM debian:buster-slim
+# All packages are MXE deps except dos2unix: https://mxe.cc/#requirements
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    autopoint \
+    bash \
+    bison \
+    bzip2 \
+    flex \
+    g++ \
+    g++-multilib \
+    gettext \
+    git \
+    gperf \
+    intltool \
+    libc6-dev-i386 \
+    libgdk-pixbuf2.0-dev \
+    libltdl-dev \
+    libssl-dev \
+    libtool-bin \
+    libxml-parser-perl \
+    lzip \
+    make \
+    openssl \
+    p7zip-full \
+    patch \
+    perl \
+    python \
+    ruby \
+    sed \
+    unzip \
+    wget \
+    xz-utils \
+    dos2unix
+
+#########################################
+# Build Qt (and cross-compiler) via MXE #
+#########################################
+WORKDIR /mxe
+# Last MXE commit with Qt 5.14. At present, plugins are broken in 5.15.
+RUN git clone https://github.com/mxe/mxe.git . && \
+    git checkout d63639ff6e39d66d5b0d489ef17840af522e6dca
+RUN make MXE_TARGETS=i686-w64-mingw32.static qtbase qtquickcontrols qtquickcontrols2 qtsvg qtgraphicaleffects && \
+    make MXE_TARGETS=i686-w64-mingw32.static clean-junk
+ENV PATH=$PATH:/mxe/usr/bin
+
+###############
+# Build aria2 #
+###############
+COPY aria2 /updater2/aria2
+# Let it build when checked out on a Windows host
+RUN find /updater2/aria2 -type f -print0 | xargs -0 dos2unix
 WORKDIR /updater2/aria2
-RUN autoreconf -i && ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-libz --without-libcares --enable-static=yes ARIA2_STATIC=yes --without-libssh2 --disable-websocket --host i686-w64-mingw32 && make clean && make -j`nproc`
-WORKDIR /updater2
-ENV PATH=/build/qt-static/bin:$PATH
-RUN qmake -config release CONFIG+=static INCLUDEPATH+=/build/qt-static/include/QtZlib QMAKE_LFLAGS+="-static -static-libgcc -static-libstdc++" && make clean && make -j`nproc`
-CMD cp release/updater2.exe /build-docker
+RUN autoreconf -i && ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-libz --without-libcares --enable-static=yes ARIA2_STATIC=yes --without-libssh2 --disable-websocket --host i686-w64-mingw32.static && make -j`nproc`
+
+#################
+# Build updater #
+#################
+COPY . /updater2
+WORKDIR /build
+RUN i686-w64-mingw32.static-qmake-qt5 -config release /updater2 && make -j`nproc`

--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ strip build-docker/updater2 # Optionally strip binary to reduce its size
 Search for **updater2** in build-docker directory.
 
 ## Build Windows version in docker
+
+The last 3 lines are to copy the result out of the container.
+
 ```
 docker build -t updater2-win -f Dockerfile.win .
-docker run -v `pwd`/build-docker:/build-docker -u `id -u $USER` updater2-win
-strip build-docker/updater2.exe # Optionally strip binary to reduce its size
+docker create --name updater2-win updater2-win
+docker cp updater2-win:/build/release/updater2.exe ./build-docker
+docker rm updater2-win
+
 ```
 Search for **updater2.exe** in build-docker directory.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ Search for **updater2** in build-docker directory.
 
 ## Build Windows version in docker
 
-The last 3 lines are to copy the result out of the container.
+If the code is checked out on a Windows host, you must ensure that the line endings in the aria2 submodule are LF. The symptom of CRLF newlines is `libtoolize: AC_CONFIG_MACRO_DIR([m4]) conflicts with ACLOCAL_AMFLAGS=-I m4`. To reset the newlines:
+
+```
+cd aria2
+git config core.autocrlf input
+git rm --cached . && git reset --hard
+```
+
+The first line below runs the Docker build for Windows. The last 3 lines are to copy the result out of the container.
 
 ```
 docker build -t updater2-win -f Dockerfile.win .


### PR DESCRIPTION
Now build Qt from scratch. This has the obvious disadvantage of taking over an hour to build. But I think it is better overall than the approach of using an image with pre-built Qt. It is easier to debug and make stages to the steps that occur before/during Qt build (e.g. testing a different Qt version), and it does not rely on a custom image which is difficult to verify. Given the very small number of people who will build the updater, I don't think it is worthwhile to maintain the pre-built Qt.