### PR TITLE
Fixes

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -79,6 +79,7 @@ int main(int argc, char *argv[])
     }
     Settings settings;
     QmlDownloader downloader;
+    downloader.checkForUpdate();
     QQmlApplicationEngine engine;
     engine.addImportPath(QLatin1String("qrc:/"));
     engine.addImageProvider(QLatin1String("fluidicons"), new IconsImageProvider());

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -4,7 +4,6 @@
 #include <QObject>
 #include <QRegularExpression>
 #include <QSettings>
-#include <QNetworkConfigurationManager>
 #include <QThread>
 #include <QUrl>
 #include <QTemporaryDir>
@@ -44,6 +43,7 @@ public:
     int totalSize() const;
     int completedSize() const;
     DownloadState state() const;
+    void checkForUpdate();
 
 signals:
     void downloadSpeedChanged(int downloadSpeed);
@@ -66,7 +66,7 @@ public slots:
     Q_INVOKABLE void startUpdate();
     Q_INVOKABLE void toggleDownload();
     Q_INVOKABLE void startGame();
-    Q_INVOKABLE void checkForUpdate();
+    Q_INVOKABLE void autoLaunchOrUpdate();
 
 private:
     void stopAria();
@@ -84,8 +84,8 @@ private:
     DownloadWorker* worker_;
     DownloadTimeCalculator downloadTime_;
     Settings settings_;
-    QNetworkConfigurationManager networkManager_;
-    QString currentVersion_;
+    QString latestGameVersion_;
+    QString latestUpdaterVersion_;
     DownloadState state_;
     std::unique_ptr<QTemporaryDir> temp_dir_;
 

--- a/splash.qml
+++ b/splash.qml
@@ -15,7 +15,10 @@ ApplicationWindow {
         interval: 3000
         repeat: false
         running: true
-        onTriggered: downloader.checkForUpdate()
+        onTriggered: {
+            settingsAction.enabled = false;
+            downloader.autoLaunchOrUpdate();
+        }
     }
 
     function showUpdater() {


### PR DESCRIPTION
The most interesting one is "Asynchronously request latest versions". This uses the splash screen timer as a timeout for the versions request. So the splash screen will never be displayed more than 3 seconds unless an updater update is being attempted. This should fix the worst of #35.