### PR TITLE
Show modal popup on game download failure

### DIFF
--- a/main.qml
+++ b/main.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import Fluid.Controls 1.0 as FluidControls
 import Fluid.Material 1.0 as FluidMaterial
+import "utils.js" as Utils
 
 ApplicationWindow {
     id: root
@@ -18,8 +19,13 @@ ApplicationWindow {
         target: downloader
         ignoreUnknownSignals: true
         onStatusMessage: {
-            console.log(message);
+            console.log("Download status: " + message);
             infoBar.open(message);
+        }
+        onFatalMessage: {
+            console.log("Installation failed: " + message);
+            errorPopup.errorDetail = message;
+            errorPopup.open();
         }
     }
 
@@ -114,6 +120,42 @@ ApplicationWindow {
         duration: 3000
         onClicked: {
             this.hide();
+        }
+    }
+
+    Popup {
+        id: errorPopup
+        modal: true
+        focus: true
+        width: 650
+        height: 400
+        closePolicy: Popup.NoAutoClose
+        anchors.centerIn: parent
+        Material.theme: Material.Dark
+        property string errorDetail
+
+        FluidControls.BodyLabel {
+            width: parent.width
+            text: ('<h2> Installation failed. </h2> ' +
+                   '<h3> %1 </h3> <br/>' +
+                   '<p> If errors persist, go to the ' +
+                   '<a href="https://forums.unvanquished.net">forums</a>, ' +
+                   '<a href="https://unvanquished.net/chat">IRC</a>, or ' +
+                   '<a href="https://discord.gg/pHwf5K2">Discord</a> ' +
+                   'for support. </p>').arg(Utils.htmlEscape(errorPopup.errorDetail))
+            textFormat: Text.StyledText
+            linkColor: "#00B2B8"
+            wrapMode: Text.WordWrap
+            font.pixelSize: 21
+            lineHeight: 24
+            onLinkActivated: {
+                Qt.openUrlExternally(link);
+            }
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.NoButton
+                cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+            }
         }
     }
 }

--- a/main.qml
+++ b/main.qml
@@ -135,6 +135,7 @@ ApplicationWindow {
         property string errorDetail
 
         FluidControls.BodyLabel {
+            id: errorPopupBody
             width: parent.width
             text: ('<h2> Installation failed. </h2> ' +
                    '<h3> %1 </h3> <br/>' +
@@ -156,6 +157,11 @@ ApplicationWindow {
                 acceptedButtons: Qt.NoButton
                 cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
             }
+        }
+
+        FluidControls.BodyLabel {
+            text: errorPopupBody.hoveredLink
+            anchors.bottom: parent.bottom
         }
     }
 }

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -97,7 +97,7 @@ void QmlDownloader::onDownloadEvent(int event)
             break;
 
         case aria2::EVENT_ON_DOWNLOAD_ERROR:
-            emit statusMessage("Error received while downloading");
+            emit fatalMessage("Error received while downloading");
             break;
 
         case aria2::EVENT_ON_DOWNLOAD_PAUSE:
@@ -113,7 +113,7 @@ void QmlDownloader::onDownloadEvent(int event)
             break;
 
         case DownloadWorker::ERROR_EXTRACTING:
-            emit statusMessage("Error extracting update");
+            emit fatalMessage("Error extracting update");
             break;
     }
 }
@@ -126,12 +126,12 @@ void QmlDownloader::startUpdate()
     QDir dir(installDir);
     if (!dir.exists()) {
         if (!dir.mkpath(dir.path())) {
-            emit statusMessage(dir.path() + " does not exist and could not be created");
+            emit fatalMessage(dir.path() + " does not exist and could not be created");
             return;
         }
     }
     if (!QFileInfo(installDir).isWritable()) {
-        emit statusMessage("Install dir not writable. Please select another");
+        emit fatalMessage("Install dir not writable. Please select another");
         return;
     }
     emit statusMessage("Installing to " + dir.canonicalPath());

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -54,6 +54,7 @@ signals:
     void totalSizeChanged(int totalSize);
     void completedSizeChanged(int completedSize);
     void statusMessage(QString message);
+    void fatalMessage(QString message);
     void updateNeeded(bool updateNeeded);
     void stateChanged(DownloadState state);
 

--- a/splash.qml
+++ b/splash.qml
@@ -38,6 +38,8 @@ ApplicationWindow {
                 downloader.startGame();
             }
         }
+
+        // TODO: respond to onFatalMessage
     }
 
     Image {

--- a/utils.js
+++ b/utils.js
@@ -27,3 +27,10 @@ function humanTime(time) {
     var secs = time % 60.0
     return '' + padZeros(hours, 2) + ':' + padZeros(mins, 2) + ':' + padZeros(secs, 2) + ' left';
 }
+
+// Suitable for use outside tags
+function htmlEscape(text) {
+    return text.replace(/&/g, '&amp;')
+               .replace(/</g, '&lt;')
+               .replace(/>/g, '&gt;')
+}


### PR DESCRIPTION
Error message for game download failure. Since there is nothing you can do in the app at this point, I didn't provide any method to close the popup. You just have to close the program.

![image](https://user-images.githubusercontent.com/7809431/104116766-3b3e7400-52e1-11eb-9244-30a48d71fa16.png)


There also still needs to be some UI displaying the error for an updater update failure. I'm not sure what to do in that case, since the splash screen windows is too small to draw a dialog in it like this one. 