### PR TITLE
Updater update UI enhancements

### DIFF
--- a/UpdateFailed.qml
+++ b/UpdateFailed.qml
@@ -1,0 +1,47 @@
+import QtQuick 2.7
+import QtQuick.Controls 2.0
+import QtQuick.Controls.Material 2.0
+import Fluid.Controls 1.0 as FluidControls
+import "utils.js" as Utils
+
+Popup {
+    modal: true
+    focus: true
+    width: 650
+    height: 400
+    closePolicy: Popup.NoAutoClose
+    anchors.centerIn: parent
+    Material.theme: Material.Dark
+    property string errorDetail
+    property string failedOperation
+
+    FluidControls.BodyLabel {
+        id: errorPopupBody
+        width: parent.width
+        text: ('<h2> ' + failedOperation + ' failed. </h2> ' +
+               '<h3>' + Utils.htmlEscape(errorDetail) + '</h3> <br/>' +
+               '<p> If errors persist, go to the ' +
+               '<a href="https://forums.unvanquished.net">forums</a>, ' +
+               '<a href="https://unvanquished.net/chat">IRC</a>, or ' +
+               '<a href="https://discord.gg/pHwf5K2">Discord</a> ' +
+               'for support. </p>')
+        textFormat: Text.StyledText
+        linkColor: "#00B2B8"
+        wrapMode: Text.WordWrap
+        font.pixelSize: 21
+        lineHeight: 24
+        onLinkActivated: {
+            Qt.openUrlExternally(link);
+        }
+        MouseArea {
+            anchors.fill: parent
+            acceptedButtons: Qt.NoButton
+            cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
+        }
+    }
+
+    FluidControls.BodyLabel {
+        text: errorPopupBody.hoveredLink
+        anchors.bottom: parent.bottom
+    }
+}

--- a/main.cpp
+++ b/main.cpp
@@ -39,6 +39,7 @@ void LogSettings() {
 struct CommandLineOptions {
     QString logFilename;
     QString ariaLogFilename;
+    int splashMilliseconds = 3000;
 };
 
 CommandLineOptions getCommandLineOptions(const QApplication& app) {
@@ -46,15 +47,22 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     logFileNameOption.setValueName("filename");
     QCommandLineOption ariaLogFilenameOption("arialogfile");
     ariaLogFilenameOption.setValueName("filename");
+    QCommandLineOption splashMsOption("splashms");
+    splashMsOption.setValueName("duration in milliseconds");
     QCommandLineParser optionParser;
     optionParser.addHelpOption();
     optionParser.addVersionOption();
     optionParser.addOption(logFileNameOption);
     optionParser.addOption(ariaLogFilenameOption);
+    optionParser.addOption(splashMsOption);
     optionParser.process(app);
     CommandLineOptions options;
     options.logFilename = optionParser.value(logFileNameOption);
     options.ariaLogFilename = optionParser.value(ariaLogFilenameOption);
+    int splashMs = optionParser.value(splashMsOption).toInt();
+    if (splashMs > 0) {
+        options.splashMilliseconds = splashMs;
+    }
     return options;
 }
 
@@ -108,6 +116,7 @@ int main(int argc, char *argv[])
     auto* context = engine.rootContext();
     context->setContextProperty("updaterSettings", &settings);
     context->setContextProperty("downloader", &downloader);
+    context->setContextProperty("splashMilliseconds", options.splashMilliseconds);
     qmlRegisterType<QmlDownloader>("QmlDownloader", 1, 0, "QmlDownloader");
 
     engine.load(QUrl(QLatin1String("qrc:/splash.qml")));

--- a/main.cpp
+++ b/main.cpp
@@ -47,6 +47,8 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     QCommandLineOption ariaLogFilenameOption("arialogfile");
     ariaLogFilenameOption.setValueName("filename");
     QCommandLineParser optionParser;
+    optionParser.addHelpOption();
+    optionParser.addVersionOption();
     optionParser.addOption(logFileNameOption);
     optionParser.addOption(ariaLogFilenameOption);
     optionParser.process(app);
@@ -61,6 +63,7 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
 int main(int argc, char *argv[])
 {
     QCoreApplication::setApplicationName("Unvanquished Updater");
+    QCoreApplication::setApplicationVersion(GIT_VERSION);
     QCoreApplication::setOrganizationName("Unvanquished Development");
     QCoreApplication::setOrganizationDomain("unvanquished.net");
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/main.qml
+++ b/main.qml
@@ -123,45 +123,8 @@ ApplicationWindow {
         }
     }
 
-    Popup {
+    UpdateFailed {
         id: errorPopup
-        modal: true
-        focus: true
-        width: 650
-        height: 400
-        closePolicy: Popup.NoAutoClose
-        anchors.centerIn: parent
-        Material.theme: Material.Dark
-        property string errorDetail
-
-        FluidControls.BodyLabel {
-            id: errorPopupBody
-            width: parent.width
-            text: ('<h2> Installation failed. </h2> ' +
-                   '<h3> %1 </h3> <br/>' +
-                   '<p> If errors persist, go to the ' +
-                   '<a href="https://forums.unvanquished.net">forums</a>, ' +
-                   '<a href="https://unvanquished.net/chat">IRC</a>, or ' +
-                   '<a href="https://discord.gg/pHwf5K2">Discord</a> ' +
-                   'for support. </p>').arg(Utils.htmlEscape(errorPopup.errorDetail))
-            textFormat: Text.StyledText
-            linkColor: "#00B2B8"
-            wrapMode: Text.WordWrap
-            font.pixelSize: 21
-            lineHeight: 24
-            onLinkActivated: {
-                Qt.openUrlExternally(link);
-            }
-            MouseArea {
-                anchors.fill: parent
-                acceptedButtons: Qt.NoButton
-                cursorShape: parent.hoveredLink ? Qt.PointingHandCursor : Qt.ArrowCursor
-            }
-        }
-
-        FluidControls.BodyLabel {
-            text: errorPopupBody.hoveredLink
-            anchors.bottom: parent.bottom
-        }
+        failedOperation: 'Game installation'
     }
 }

--- a/qml.qrc
+++ b/qml.qrc
@@ -7,6 +7,7 @@
         <file>News.qml</file>
         <file>NewsCard.qml</file>
         <file>DownloadInfo.qml</file>
+        <file>UpdateFailed.qml</file>
         <file>resources/splash.png</file>
         <file>splash.qml</file>
         <file>Settings.qml</file>

--- a/splash.qml
+++ b/splash.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
+import Fluid.Controls 1.0 as FluidControls
 import Fluid.Material 1.0
 
 ApplicationWindow {
@@ -48,6 +49,16 @@ ApplicationWindow {
         source: "qrc:/resources/splash.png"
     }
 
+    FluidControls.BodyLabel {
+        Material.theme: Material.Dark
+        text: "Updating launcher..."
+        visible: downloader.totalSize > 0
+        anchors.bottom: updaterUpdateProgress.top
+        anchors.left: parent.left
+        anchors.margins: { left: 20 }
+        font.pixelSize: 17
+    }
+
     ActionButton {
         id: settingsAction
         scale: 0.8
@@ -68,6 +79,7 @@ ApplicationWindow {
     }
 
     ProgressBar {
+        id: updaterUpdateProgress
         anchors.bottom: parent.bottom
         width: parent.width
         from: 0.0
@@ -76,7 +88,6 @@ ApplicationWindow {
         value: downloader.completedSize / downloader.totalSize
         Material.accent: Material.Teal
     }
-
 
     Loader {
         id: updaterWindowLoader

--- a/splash.qml
+++ b/splash.qml
@@ -23,11 +23,13 @@ ApplicationWindow {
     }
 
     function showUpdater() {
+        splashConnections.enabled = false;
         updaterWindowLoader.active = true
         splash.hide();
     }
 
     Connections {
+        id: splashConnections
         target: downloader
         ignoreUnknownSignals: true
 
@@ -40,7 +42,12 @@ ApplicationWindow {
             }
         }
 
-        // TODO: respond to onFatalMessage
+        onFatalMessage: {
+            updateFailed.errorDetail = message;
+            updateFailedWindow.show();
+            updateFailed.open();
+            splash.hide();
+        }
     }
 
     Image {
@@ -93,5 +100,18 @@ ApplicationWindow {
         id: updaterWindowLoader
         active: false
         source: "qrc:/main.qml"
+    }
+
+    ApplicationWindow {
+        id: updateFailedWindow
+        visible: false
+        width: updateFailed.width
+        height: updateFailed.height
+        maximumWidth: updateFailed.width
+        maximumHeight: updateFailed.height
+        UpdateFailed {
+            id: updateFailed
+            failedOperation: 'Launcher self-update'
+        }
     }
 }

--- a/splash.qml
+++ b/splash.qml
@@ -12,7 +12,7 @@ ApplicationWindow {
 
     Timer {
         id: timer
-        interval: 3000
+        interval: splashMilliseconds
         repeat: false
         running: true
         onTriggered: {


### PR DESCRIPTION
Show "Updating launcher" message on splash screen:

![updating launcher](https://user-images.githubusercontent.com/7809431/104241338-21a54580-5423-11eb-9c0a-ebfc3a724bd1.png)

Hide splash and show error message (reusing code from #70) when updater update fails:
![errror selfupdate](https://user-images.githubusercontent.com/7809431/104241356-2bc74400-5423-11eb-9e3c-575cc365f27e.PNG)

Fixes #54.
