### PR TITLE
Use updater as launcher on Mac and Linux

### DIFF
--- a/osx.cpp
+++ b/osx.cpp
@@ -56,6 +56,27 @@ bool install()
     return true;
 }
 
+bool installUpdater(const QString& installPath) {
+    QString currentAppPath = extractAppPath(QCoreApplication::applicationFilePath());
+    if (currentAppPath.isEmpty()) return false;
+    QDir src(currentAppPath);
+    QDir dest(installPath + QDir::separator() + "updater.app");
+    if (src == dest) {
+        qDebug() << "Updater already in install location";
+        return true;
+    }
+    if (dest.exists()) {
+        qDebug() << "Deleting updater in install path";
+        if (!dest.removeRecursively()) {
+            return false;
+        }
+    }
+    qDebug() << "Copying updater from" << src.absolutePath();
+    int ret = QProcess::execute("/bin/cp", {QString("-R"), src.path(), dest.path()});
+    qDebug() << "cp returned" << ret;
+    return ret == 0;
+}
+
 bool updateUpdater(const QString& updaterArchive)
 {
     QString currentAppPath = extractAppPath(QCoreApplication::applicationFilePath());

--- a/osx.cpp
+++ b/osx.cpp
@@ -50,9 +50,19 @@ bool validateInstallPath(const QString&)
 
 bool install()
 {
+    QDir applications(QDir::homePath() + "/Applications");
+    if (!applications.exists()) {
+        if (!applications.mkpath(".")) {
+            qDebug() << "can't create ~/Applications";
+            return false;
+        }
+    }
     Settings settings;
-    QFile::link(settings.installPath() + "/Unvanquished.app",
-	            QDir::homePath() + "/Applications/Unvanquished.app");
+    if (!QFile::link(settings.installPath() + QDir::separator() + "updater.app",
+                     applications.absoluteFilePath("Unvanquished.app"))) {
+        qDebug() << "failed to create Applications link";
+        return false;
+    }
     return true;
 }
 

--- a/qml.qrc
+++ b/qml.qrc
@@ -17,7 +17,8 @@
         <file>resources/header.png</file>
         <file>resources/logo.png</file>
         <file>resources/tyrant.png</file>
-        <file>resources/unvanquished.desktop</file>
+        <file>resources/net.unvanquished.Unvanquished.desktop</file>
+        <file>resources/net.unvanquished.UnvanquishedProtocolHandler.desktop</file>
         <file>resources/disconnected_posts.json</file>
     </qresource>
 </RCC>

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -73,6 +73,11 @@ void QmlDownloader::onDownloadEvent(int event)
     switch (event) {
         case aria2::EVENT_ON_BT_DOWNLOAD_COMPLETE:
             if (state() != COMPLETED) {
+                qDebug() << "installUpdater in" << settings_.installPath();
+                if (!Sys::installUpdater(settings_.installPath())) {
+                    emit fatalMessage("Error installing launcher");
+                    return;
+                }
                 qDebug() << "Calling Sys::install";
                 Sys::install();
                 // FIXME: latestGameVersion_ could be empty if CurrentVersionFetcher didn't succeed

--- a/resources/net.unvanquished.Unvanquished.desktop
+++ b/resources/net.unvanquished.Unvanquished.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
-Version=1.0
+Version=1.5
 Name=Unvanquished
 Comment=FPS/RTS Game - Aliens vs. Humans
 Icon=unvanquished
 Terminal=false
 Type=Application
-Exec=%1/daemon -connect %U
+Exec="%1/updater"
 Categories=Game;ActionGame;StrategyGame;
-MimeType=x-scheme-handler/unv
+# Probably doesn't work since the updater is initially launched, not daemon
+PrefersNonDefaultGPU=true

--- a/resources/net.unvanquished.UnvanquishedProtocolHandler.desktop
+++ b/resources/net.unvanquished.UnvanquishedProtocolHandler.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.5
+Name=Unvanquished (protocol handler)
+NoDisplay=true
+Terminal=false
+Type=Application
+Exec="%1/daemon" -connect %u
+MimeType=x-scheme-handler/unv
+# Unclear if this will work when Breakpad is enabled
+PrefersNonDefaultGPU=true

--- a/system.h
+++ b/system.h
@@ -11,6 +11,7 @@ QString archiveName();
 QString defaultInstallPath();
 bool validateInstallPath(const QString& installPath); // Checks installing as root in homepath on Linux
 bool install();
+bool installUpdater(const QString& installPath); // Copies current application to <install path>/updater[.exe|.app]
 bool updateUpdater(const QString& updaterArchive);
 QString updaterArchiveName();
 std::string getCertStore();

--- a/unix.cpp
+++ b/unix.cpp
@@ -101,6 +101,25 @@ bool install()
     return true;
 }
 
+bool installUpdater(const QString& installPath) {
+    QFileInfo src(QCoreApplication::applicationFilePath());
+    QFileInfo dest(installPath + QDir::separator() + "updater");
+    if (src == dest) {
+        qDebug() << "Updater already in install location";
+        return true;
+    }
+    if (dest.exists()) {
+        qDebug() << "Deleting updater in install path";
+        if (!QFile::remove(dest.filePath())) {
+            return false;
+        }
+    }
+    qDebug() << "Copying updater from" << src.absoluteFilePath();
+    return QFile::copy(src.absoluteFilePath(), dest.filePath()) &&
+           QFile::setPermissions(dest.filePath(), static_cast<QFileDevice::Permissions>(0x775));
+           // Yes it is really supposed to be 0x775 not 0775
+}
+
 bool updateUpdater(const QString& updaterArchive)
 {
     QString current = QCoreApplication::applicationFilePath();

--- a/updater2.pro
+++ b/updater2.pro
@@ -44,6 +44,10 @@ unix:LIBS += -lz "-L$$PWD/aria2/src/.libs" -laria2
 
 win32:RC_FILE = updater.rc
 
+# Plain Unvanquished icon, used for the app bundle and hence the Launchpad shortcut.
+# When the updater is running, the one with arrows is displayed as its icon.
+mac: ICON = resources/Unvanquished.icns
+
 # Additional import path used to resolve QML modules in Qt Creator's code model
 QML_IMPORT_PATH += fluid/src/imports/controls/qmldir
 

--- a/updater2.pro
+++ b/updater2.pro
@@ -65,12 +65,3 @@ DEFINES += QT_DEPRECATED_WARNINGS
 qnx: target.path = /tmp/$${TARGET}/bin
 else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
-
-DISTFILES += \
-    resources/unvanquished.desktop \
-    resources/unvanquished.png \
-    resources/background.png \
-    resources/header.png \
-    resources/logo.png \
-    resources/tyrant.png \
-    resources/disconnected_posts.json

--- a/win.cpp
+++ b/win.cpp
@@ -181,6 +181,23 @@ bool install()
     return true;
 }
 
+bool installUpdater(const QString& installPath) {
+    QFileInfo src(QCoreApplication::applicationFilePath());
+    QFileInfo dest(installPath + QDir::separator() + "updater.exe");
+    if (src == dest) {
+        qDebug() << "Updater already in install location";
+        return true;
+    }
+    if (dest.exists()) {
+        qDebug() << "Deleting updater in install path";
+        if (!QFile::remove(dest.filePath())) {
+            return false;
+        }
+    }
+    qDebug() << "Copying updater from" << src.absoluteFilePath();
+    return QFile::copy(src.absoluteFilePath(), dest.filePath());
+}
+
 bool updateUpdater(const QString& updaterArchive)
 {
     QString current = QCoreApplication::applicationFilePath();


### PR DESCRIPTION
Also fix the unv:// protocol handler on Linux (it's not implemented on Mac).

Still need some adjustments with admin elevations before switching to the launcher for Windows.

Fixes #34.