### PR TITLE
Windows Docker: use own Qt build instead of MXE

### DIFF
--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -11,50 +11,40 @@
 # is stored in the updater2/.git/modules directory.
 
 FROM debian:buster-slim
-# All packages are MXE deps: https://mxe.cc/#requirements
 RUN apt-get update && apt-get install -y \
     autoconf \
-    automake \
     autopoint \
-    bash \
-    bison \
-    bzip2 \
-    flex \
-    g++ \
-    g++-multilib \
+    curl \
     gettext \
+    g++ \
+    g++-mingw-w64-i686 \
     git \
-    gperf \
-    intltool \
-    libc6-dev-i386 \
-    libgdk-pixbuf2.0-dev \
-    libltdl-dev \
-    libssl-dev \
-    libtool-bin \
-    libxml-parser-perl \
-    lzip \
+    libtool \
     make \
-    openssl \
-    p7zip-full \
-    patch \
-    perl \
+    pkg-config \
     python \
-    ruby \
-    sed \
-    unzip \
-    wget \
     xz-utils
 
-#########################################
-# Build Qt (and cross-compiler) via MXE #
-#########################################
-WORKDIR /mxe
-# Last MXE commit with Qt 5.14. At present, plugins are broken in 5.15.
-RUN git clone https://github.com/mxe/mxe.git . && \
-    git checkout d63639ff6e39d66d5b0d489ef17840af522e6dca
-RUN make MXE_TARGETS=i686-w64-mingw32.static qtbase qtquickcontrols qtquickcontrols2 qtsvg qtgraphicaleffects && \
-    make MXE_TARGETS=i686-w64-mingw32.static clean-junk && rm -rf pkg/ .ccache/
-ENV PATH=$PATH:/mxe/usr/bin
+# Something in Qt does not build with win32 thread flavor
+RUN update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix && \
+    update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
+
+# The Schannel dependencies are spelled with capital letters which causes them not to be found
+RUN ln -s libsecur32.a /usr/i686-w64-mingw32/lib/libSecur32.a && \
+    ln -s libcrypt32.a /usr/i686-w64-mingw32/lib/libCrypt32.a
+
+############
+# Build Qt #
+############
+WORKDIR /build-qt
+ENV UPDATER_MODULES=qtbase,qtquickcontrols,qtquickcontrols2,qtsvg,qtgraphicaleffects
+RUN curl -LO https://download.qt.io/archive/qt/5.14/5.14.2/single/qt-everywhere-src-5.14.2.tar.xz && \
+    curl -L https://download.qt.io/archive/qt/5.14/5.14.2/single/md5sums.txt | md5sum --check --ignore-missing && \
+    tar -xJf qt-everywhere-src-5.14.2.tar.xz && \
+    cd qt-everywhere-src-5.14.2 && \
+    ./configure -release -static -prefix /qt -qt-zlib -qt-libjpeg -qt-libpng -qt-freetype -qt-pcre -qt-harfbuzz -opengl desktop -opensource -confirm-license -no-qml-debug -no-icu -xplatform win32-g++ -device-option CROSS_COMPILE=i686-w64-mingw32- -optimize-size --c++std=14 -nomake tests -nomake tools -nomake examples -schannel && \
+    bash -c "make -j`nproc` module-{$UPDATER_MODULES} && make module-{$UPDATER_MODULES}-install_subtargets" && \
+    rm -rf /build-qt
 
 ###############
 # Build aria2 #
@@ -63,7 +53,7 @@ COPY aria2 /updater2/aria2
 COPY .git/modules/aria2 /updater2/.git/modules/aria2
 WORKDIR /updater2/aria2
 RUN git clean -dXff
-RUN autoreconf -i && ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-libz --without-libcares --enable-static=yes ARIA2_STATIC=yes --without-libssh2 --disable-websocket --disable-nls --host i686-w64-mingw32.static && make -j`nproc`
+RUN autoreconf -i && ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-libz --without-libcares --enable-static=yes ARIA2_STATIC=yes --without-libssh2 --disable-websocket --disable-nls --host i686-w64-mingw32 && make -j`nproc`
 
 #################
 # Build updater #
@@ -71,4 +61,4 @@ RUN autoreconf -i && ./configure --without-libxml2 --without-libexpat --without-
 COPY . /updater2
 RUN set -e; for D in . quazip fluid; do cd /updater2/$D && git clean -dXff; done
 WORKDIR /build
-RUN i686-w64-mingw32.static-qmake-qt5 -config release /updater2 && make -j`nproc`
+RUN /qt/bin/qmake -config release QMAKE_LFLAGS+="-static" INCLUDEPATH+=/qt/include/QtZlib /updater2 && make -j`nproc`


### PR DESCRIPTION
I'm doing this because using MXE leads to a binary size regression. We
can't add options like -optimize-size when using MXE.

updater2.exe sizes:
	v0.0.5 release - 28.9M
	with MXE (old Dockerfile.win) - 40.4M
	new Dockerfile.win - 24.6M

Compared to the Docker script used before MXE which built our own Qt
5.9, the -schannel flag is added to Qt's configure, which is what was
needed for https to work in the Qt network library.