### PR TITLE
Use updater as launcher on Windows

### DIFF
--- a/DownloadInfo.qml
+++ b/DownloadInfo.qml
@@ -164,7 +164,7 @@ Item {
                 downloader.startGame();
                 return;
             }
-            downloader.toggleDownload();
+            downloader.toggleDownload(selectedInstallPath);
         }
     }
 

--- a/Settings.qml
+++ b/Settings.qml
@@ -28,7 +28,7 @@ Item {
                 padding: 16
             }
             FluidControls.Subheader {
-                text: updaterSettings.installPath
+                text: selectedInstallPath
             }
             FluidMaterial.ActionButton {
                 Material.elevation: 1
@@ -64,7 +64,7 @@ Item {
             if (Qt.platform.os === "windows") {
                 path = path.replace(/\//g, '\\');
             }
-            updaterSettings.installPath = path;
+            selectedInstallPath = path;
         }
         selectFolder: true
     }

--- a/downloadworker.cpp
+++ b/downloadworker.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include "downloadworker.h"
 #include "quazip/quazip/JlCompress.h"
+#include "settings.h"
 #include "system.h"
 #include <QDebug>
 
@@ -159,6 +160,8 @@ void DownloadWorker::stop()
 
 bool DownloadWorker::extractUpdate()
 {
+    qDebug() << "Clearing installed version prior to extraction";
+    Settings().setCurrentVersion("");
     QString filename = Sys::archiveName();
     auto out = JlCompress::extractDir(downloadDir + "/" + filename, downloadDir);
     if (out.size() < 1) {

--- a/downloadworker.cpp
+++ b/downloadworker.cpp
@@ -60,9 +60,9 @@ void DownloadWorker::onDownloadCallback(aria2::Session* session, aria2::Download
                 Sys::updateUpdater(QString(files[0].path.c_str()));
                 return;
             } else {
-                qDebug() << "Unvanquished download complete (?)";
-                event = aria2::EVENT_ON_BT_DOWNLOAD_COMPLETE;
-                if (!extractUpdate()) return;
+                // For a torrent, happens when aria2 is stopped
+                qDebug() << "final EVENT_ON_DOWNLOAD_COMPLETE";
+                return;
             }
             break;
 

--- a/main.cpp
+++ b/main.cpp
@@ -41,6 +41,7 @@ struct CommandLineOptions {
     QString ariaLogFilename;
     int splashMilliseconds = 3000;
     QString updateUpdaterVersion;
+    bool updateGame;
 };
 
 CommandLineOptions getCommandLineOptions(const QApplication& app) {
@@ -52,6 +53,7 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     splashMsOption.setValueName("duration in milliseconds");
     QCommandLineOption updateUpdaterOption("updateupdaterto");
     updateUpdaterOption.setValueName("updater version");
+    QCommandLineOption updateGameOption("updategame");
     QCommandLineParser optionParser;
     optionParser.addHelpOption();
     optionParser.addVersionOption();
@@ -59,6 +61,7 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     optionParser.addOption(ariaLogFilenameOption);
     optionParser.addOption(splashMsOption);
     optionParser.addOption(updateUpdaterOption);
+    optionParser.addOption(updateGameOption);
     optionParser.process(app);
     CommandLineOptions options;
     options.logFilename = optionParser.value(logFileNameOption);
@@ -68,6 +71,7 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
         options.splashMilliseconds = splashMs;
     }
     options.updateUpdaterVersion = optionParser.value(updateUpdaterOption);
+    options.updateGame = optionParser.isSet(updateGameOption);
     return options;
 }
 
@@ -118,6 +122,9 @@ int main(int argc, char *argv[])
         // Don't request versions.json because it would clobber the verson
     } else {
         downloader.checkForUpdate();
+        if (options.updateGame) {
+            downloader.forceGameUpdate();
+        }
     }
     QQmlApplicationEngine engine;
     engine.addImportPath(QLatin1String("qrc:/"));

--- a/main.cpp
+++ b/main.cpp
@@ -51,9 +51,9 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     ariaLogFilenameOption.setValueName("filename");
     QCommandLineOption splashMsOption("splashms");
     splashMsOption.setValueName("duration in milliseconds");
-    QCommandLineOption updateUpdaterOption("updateupdaterto");
+    QCommandLineOption updateUpdaterOption("update-updater-to");
     updateUpdaterOption.setValueName("updater version");
-    QCommandLineOption updateGameOption("updategame");
+    QCommandLineOption updateGameOption("update-game");
     QCommandLineParser optionParser;
     optionParser.addHelpOption();
     optionParser.addVersionOption();

--- a/main.cpp
+++ b/main.cpp
@@ -40,6 +40,7 @@ struct CommandLineOptions {
     QString logFilename;
     QString ariaLogFilename;
     int splashMilliseconds = 3000;
+    QString updateUpdaterVersion;
 };
 
 CommandLineOptions getCommandLineOptions(const QApplication& app) {
@@ -49,12 +50,15 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     ariaLogFilenameOption.setValueName("filename");
     QCommandLineOption splashMsOption("splashms");
     splashMsOption.setValueName("duration in milliseconds");
+    QCommandLineOption updateUpdaterOption("updateupdaterto");
+    updateUpdaterOption.setValueName("updater version");
     QCommandLineParser optionParser;
     optionParser.addHelpOption();
     optionParser.addVersionOption();
     optionParser.addOption(logFileNameOption);
     optionParser.addOption(ariaLogFilenameOption);
     optionParser.addOption(splashMsOption);
+    optionParser.addOption(updateUpdaterOption);
     optionParser.process(app);
     CommandLineOptions options;
     options.logFilename = optionParser.value(logFileNameOption);
@@ -63,6 +67,7 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     if (splashMs > 0) {
         options.splashMilliseconds = splashMs;
     }
+    options.updateUpdaterVersion = optionParser.value(updateUpdaterOption);
     return options;
 }
 
@@ -108,7 +113,12 @@ int main(int argc, char *argv[])
     Settings settings;
     QmlDownloader downloader;
     downloader.ariaLogFilename_ = options.ariaLogFilename;
-    downloader.checkForUpdate();
+    if (!options.updateUpdaterVersion.isEmpty()) {
+        downloader.forceUpdaterUpdate(options.updateUpdaterVersion);
+        // Don't request versions.json because it would clobber the verson
+    } else {
+        downloader.checkForUpdate();
+    }
     QQmlApplicationEngine engine;
     engine.addImportPath(QLatin1String("qrc:/"));
     engine.addImageProvider(QLatin1String("fluidicons"), new IconsImageProvider());

--- a/main.qml
+++ b/main.qml
@@ -15,6 +15,8 @@ ApplicationWindow {
     Material.primary: Material.DarkBlue
     Material.accent: Material.Violet
 
+    property string selectedInstallPath: updaterSettings.installPath
+
     Connections {
         target: downloader
         ignoreUnknownSignals: true

--- a/osx.cpp
+++ b/osx.cpp
@@ -181,4 +181,9 @@ bool startGame(const QString& commandLine)
     }
 }
 
+ElevationResult RelaunchElevated(const QString& flags)
+{
+    return ElevationResult::UNNEEDED;
+}
+
 }  // namespace Sys

--- a/osx.cpp
+++ b/osx.cpp
@@ -48,7 +48,7 @@ bool validateInstallPath(const QString&)
     return true;
 }
 
-bool install()
+bool installShortcuts()
 {
     QDir applications(QDir::homePath() + "/Applications");
     if (!applications.exists()) {

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -262,7 +262,7 @@ void QmlDownloader::autoLaunchOrUpdate()
                (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION))) {
         qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
         if (!forceUpdaterUpdate_) {
-            switch (Sys::RelaunchElevated("--splashms 1 --updateupdaterto " + latestUpdaterVersion_)) {
+            switch (Sys::RelaunchElevated("--splashms 1 --update-updater-to " + latestUpdaterVersion_)) {
                 case Sys::ElevationResult::UNNEEDED:
                     break;
                 case Sys::ElevationResult::RELAUNCHED:
@@ -290,7 +290,7 @@ void QmlDownloader::autoLaunchOrUpdate()
     } else if (settings_.currentVersion().isEmpty() ||
                (!latestGameVersion_.isEmpty() && settings_.currentVersion() != latestGameVersion_)) {
         qDebug() << "Game update required.";
-        switch (Sys::RelaunchElevated("--splashms 1 --updategame")) {
+        switch (Sys::RelaunchElevated("--splashms 1 --update-game")) {
             case Sys::ElevationResult::UNNEEDED:
                 break;
             case Sys::ElevationResult::RELAUNCHED:
@@ -310,7 +310,7 @@ void QmlDownloader::autoLaunchOrUpdate()
 bool QmlDownloader::relaunchForSettings()
 {
     qDebug() << "Possibly relaunching to open settings window";
-    return Sys::RelaunchElevated("--splashms 1 --updategame") != Sys::ElevationResult::UNNEEDED;
+    return Sys::RelaunchElevated("--splashms 1 --update-game") != Sys::ElevationResult::UNNEEDED;
 }
 
 QmlDownloader::DownloadState QmlDownloader::state() const

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -88,12 +88,15 @@ void QmlDownloader::onDownloadEvent(int event)
                     return;
                 }
                 qDebug() << "Calling Sys::install";
-                Sys::install();
+                if (Sys::installShortcuts()) {
+                    emit statusMessage("Up to date");
+                } else {
+                    emit statusMessage("Error installing shortcuts");
+                }
                 setState(COMPLETED);
                 setDownloadSpeed(0);
                 setUploadSpeed(0);
                 setCompletedSize(totalSize_);
-                emit statusMessage("Up to date");
                 stopAria();
             }
             break;

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -18,6 +18,7 @@ QmlDownloader::QmlDownloader() : downloadSpeed_(0),
         totalSize_(0),
         completedSize_(0),
         worker_(nullptr),
+        forceUpdaterUpdate_(false),
         state_(IDLE) {}
 
 QmlDownloader::~QmlDownloader()
@@ -201,6 +202,13 @@ void QmlDownloader::checkForUpdate()
     fetcher_.fetchCurrentVersion("https://dl.unvanquished.net/versions.json");
 }
 
+// Initiate updater update to specified version
+void QmlDownloader::forceUpdaterUpdate(const QString& version)
+{
+    forceUpdaterUpdate_ = true;
+    latestUpdaterVersion_ = version;
+}
+
 // Receives the results of the checkForUpdate request.
 void QmlDownloader::onCurrentVersions(QString updater, QString game)
 {
@@ -214,7 +222,8 @@ void QmlDownloader::onCurrentVersions(QString updater, QString game)
 void QmlDownloader::autoLaunchOrUpdate()
 {
     qDebug() << "Previously-installed game version:" << settings_.currentVersion();
-    if (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION)) {
+    if (forceUpdaterUpdate_ ||
+        (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION))) {
         qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
         QString url = UPDATER_BASE_URL + "/" + latestUpdaterVersion_ + "/" + Sys::updaterArchiveName();
         temp_dir_.reset(new QTemporaryDir());

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -19,6 +19,7 @@ QmlDownloader::QmlDownloader() : downloadSpeed_(0),
         completedSize_(0),
         worker_(nullptr),
         forceUpdaterUpdate_(false),
+        forceGameUpdate_(false),
         state_(IDLE) {}
 
 QmlDownloader::~QmlDownloader()
@@ -209,6 +210,12 @@ void QmlDownloader::forceUpdaterUpdate(const QString& version)
     latestUpdaterVersion_ = version;
 }
 
+// Launch the update window later even if the installed and current game versions match
+void QmlDownloader::forceGameUpdate()
+{
+    forceGameUpdate_ = true;
+}
+
 // Receives the results of the checkForUpdate request.
 void QmlDownloader::onCurrentVersions(QString updater, QString game)
 {
@@ -222,8 +229,11 @@ void QmlDownloader::onCurrentVersions(QString updater, QString game)
 void QmlDownloader::autoLaunchOrUpdate()
 {
     qDebug() << "Previously-installed game version:" << settings_.currentVersion();
-    if (forceUpdaterUpdate_ ||
-        (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION))) {
+    if (forceGameUpdate_) {
+        qDebug() << "Game update menu requested";
+        emit updateNeeded(true);
+    } else if (forceUpdaterUpdate_ ||
+               (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION))) {
         qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
         QString url = UPDATER_BASE_URL + "/" + latestUpdaterVersion_ + "/" + Sys::updaterArchiveName();
         temp_dir_.reset(new QTemporaryDir());

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -68,8 +68,7 @@ public slots:
     void onDownloadEvent(int event);
     void onCurrentVersions(QString updater, QString game);
 
-    Q_INVOKABLE void startUpdate();
-    Q_INVOKABLE void toggleDownload();
+    Q_INVOKABLE void toggleDownload(QString installPath);
     Q_INVOKABLE void startGame();
     Q_INVOKABLE void autoLaunchOrUpdate();
 
@@ -77,6 +76,7 @@ private:
     void stopAria();
     void setState(DownloadState state);
     void startDownload(const QUrl& url, const QDir& destination);
+    void startUpdate(const QString& selectedInstallPath);
 
     QThread thread_;
     int downloadSpeed_;

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -44,6 +44,7 @@ public:
     int completedSize() const;
     DownloadState state() const;
     void checkForUpdate();
+    void forceUpdaterUpdate(const QString& version);
 
     QString ariaLogFilename_;
 
@@ -87,6 +88,7 @@ private:
     DownloadWorker* worker_;
     DownloadTimeCalculator downloadTime_;
     Settings settings_;
+    bool forceUpdaterUpdate_;
     QString latestGameVersion_;
     QString latestUpdaterVersion_;
     DownloadState state_;

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -45,6 +45,7 @@ public:
     DownloadState state() const;
     void checkForUpdate();
     void forceUpdaterUpdate(const QString& version);
+    void forceGameUpdate();
 
     QString ariaLogFilename_;
 
@@ -89,6 +90,7 @@ private:
     DownloadTimeCalculator downloadTime_;
     Settings settings_;
     bool forceUpdaterUpdate_;
+    bool forceGameUpdate_;
     QString latestGameVersion_;
     QString latestUpdaterVersion_;
     DownloadState state_;

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -71,12 +71,14 @@ public slots:
     Q_INVOKABLE void toggleDownload(QString installPath);
     Q_INVOKABLE void startGame();
     Q_INVOKABLE void autoLaunchOrUpdate();
+    Q_INVOKABLE bool relaunchForSettings();
 
 private:
     void stopAria();
     void setState(DownloadState state);
     void startDownload(const QUrl& url, const QDir& destination);
     void startUpdate(const QString& selectedInstallPath);
+    void launchGameIfInstalled();
 
     QThread thread_;
     int downloadSpeed_;

--- a/resources/windows_manifest.xml
+++ b/resources/windows_manifest.xml
@@ -7,7 +7,7 @@
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
       <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
-        <requestedExecutionLevel level="requireAdministrator"/>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
       </requestedPrivileges>
     </security>
   </trustInfo>

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,4 +1,5 @@
 #include "settings.h"
+#include <QRandomGenerator>
 #include "system.h"
 
 const char kDefaultCommand[] = "%command%";
@@ -42,4 +43,14 @@ void Settings::setCurrentVersion(const QString& currentVersion) {
 void Settings::sync()
 {
     settings_->sync();
+}
+
+// This is a hack to detect whether the program is running as administrator on Windows,
+// by testing whether it can write in HKEY_LOCAL_MACHINE in the registry
+QSettings::Status Settings::testWrite()
+{
+    QString randomData = QString::number(QRandomGenerator::global()->generate64());
+    settings_->setValue(WRITE_PROBE, randomData);
+    sync();
+    return settings_->status();
 }

--- a/settings.h
+++ b/settings.h
@@ -15,6 +15,7 @@ public:
     const QString COMMAND_LINE = "settings/commandLineParameters";
     const QString CURRENT_VERSION = "settings/currentVersion";
     // const QString INSTALL_FINISHED = "settings/installFinished";  // No longer used
+    const QString WRITE_PROBE = "writeProbe";
 
     Settings();
 
@@ -27,6 +28,7 @@ public:
     void setCommandLine(const QString& commandLine);
     void setCurrentVersion(const QString& currentVersion);
     void sync();
+    QSettings::Status testWrite();
 
 signals:
     void installPathChanged(QString installPath);

--- a/settings.h
+++ b/settings.h
@@ -20,6 +20,7 @@ public:
 
     QString installPath() const;
     QString commandLine() const;
+    // currentVersion should be a non-empty iff there is a usable installation at installPath
     QString currentVersion() const;
 
     void setInstallPath(const QString& installPath);

--- a/splash.qml
+++ b/splash.qml
@@ -80,8 +80,12 @@ ApplicationWindow {
         Material.elevation: 0
         Material.background: Material.Teal
         onClicked: {
-            showUpdater();
             timer.stop();
+            if (downloader.relaunchForSettings()) {
+                splash.close();
+            } else {
+                showUpdater();
+            }
         }
     }
 

--- a/system.h
+++ b/system.h
@@ -19,6 +19,15 @@ QSettings* makePersistentSettings(QObject* parent);
 QString getGameCommand(const QString& installPath); // Substitution for %command%
 bool startGame(const QString& commandLine);
 
+// Windows: relaunch with UAC elevation if necessary
+// Other platforms always return UNNEEDED
+enum class ElevationResult {
+    UNNEEDED,
+    RELAUNCHED,
+    FAILED,
+};
+ElevationResult RelaunchElevated(const QString& flags);
+
 inline QString QuoteQProcessCommandArgument(QString arg)
 {
     arg.replace('"', "\"\"\"");

--- a/system.h
+++ b/system.h
@@ -10,7 +10,7 @@ namespace Sys {
 QString archiveName();
 QString defaultInstallPath();
 bool validateInstallPath(const QString& installPath); // Checks installing as root in homepath on Linux
-bool install();
+bool installShortcuts(); // Install launch menu entries and protocol handlers
 bool installUpdater(const QString& installPath); // Copies current application to <install path>/updater[.exe|.app]
 bool updateUpdater(const QString& updaterArchive);
 QString updaterArchiveName();

--- a/unix.cpp
+++ b/unix.cpp
@@ -257,4 +257,9 @@ bool startGame(const QString& commandLine)
     return false;
 }
 
+ElevationResult RelaunchElevated(const QString& flags)
+{
+    return ElevationResult::UNNEEDED;
+}
+
 }  // namespace Sys

--- a/unix.cpp
+++ b/unix.cpp
@@ -92,7 +92,7 @@ bool validateInstallPath(const QString& installPath)
     return !(installPath.endsWith("/base") && getuid() == 0);
 }
 
-bool install()
+bool installShortcuts()
 {
     // Set up menu and protocol handler
     Settings settings;
@@ -135,9 +135,8 @@ bool install()
             return false;
         }
     }
-    QFile::copy(":resources/unvanquished.png",
-                iconDir + "unvanquished.png");
-    return true;
+    QFile::remove(iconDir + "unvanquished.png");
+    return QFile::copy(":resources/unvanquished.png", iconDir + "unvanquished.png");
 }
 
 bool installUpdater(const QString& installPath) {

--- a/win.cpp
+++ b/win.cpp
@@ -270,9 +270,13 @@ QString getGameCommand(const QString& installPath)
 
 bool startGame(const QString& commandLine)
 {
+    if (Settings().testWrite() == QSettings::AccessError) {
+        qDebug() << "not admin, start game normally";
+        return QProcess::startDetached(commandLine);
+    }
     std::wstring program, args;
     SplitFirstArg(commandLine.toStdWString(), &program, &args);
-    qDebug() << "startGame: program =" << program << "args =" << args;
+    qDebug() << "startGame de-elevated: program =" << program << "args =" << args;
     HRESULT result = ShellExecInExplorerProcess(program.c_str(), args.c_str());
     qDebug() << "startGame HRESULT:" << result;
     // It returns 1 "S_FALSE" (which is considered a success by SUCCEEDED) if the application

--- a/win.cpp
+++ b/win.cpp
@@ -150,7 +150,7 @@ bool validateInstallPath(const QString&)
     return true;
 }
 
-bool install()
+bool installShortcuts()
 {
     Settings settings;
     QString installPath = settings.installPath();
@@ -169,7 +169,7 @@ bool install()
     // the game globally.
     QString startPath;
     if (!GetStartMenuPath(installPath, &startPath)) {
-        return true;
+        return false;
     }
     QDir dir(startPath);
     dir.mkdir("Unvanquished");
@@ -177,6 +177,7 @@ bool install()
     QString linkName = "Unvanquished";
     if (!CreateLink(installPath + "\\daemon.exe", installPath, dir.path() + "\\Unvanquished.lnk", linkName)) {
         qDebug() << "Creating shortcut failed";
+        return false;
     }
     return true;
 }

--- a/win.cpp
+++ b/win.cpp
@@ -255,10 +255,12 @@ std::string getCertStore()
     return "";  // Not used on Windows.
 }
 
-// Settings are stored in the registry at HKEY_CURRENT_USER\Software\Unvanquished Development\Unvanquished Updater
+// Settings are stored in the registry at (on 64-bit Windows)
+// HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Unvanquished Development\Unvanquished Updater
+// ≤v0.0.5 used HKEY_CURRENT_USER\Software\Unvanquished Development\Unvanquished Updater
 QSettings* makePersistentSettings(QObject* parent)
 {
-    return new QSettings(parent);
+    return new QSettings(QSettings::SystemScope, parent);
 }
 
 QString getGameCommand(const QString& installPath)

--- a/win.cpp
+++ b/win.cpp
@@ -175,7 +175,7 @@ bool installShortcuts()
     dir.mkdir("Unvanquished");
     dir.setPath(dir.path() + "\\Unvanquished");
     QString linkName = "Unvanquished";
-    if (!CreateLink(installPath + "\\daemon.exe", installPath, dir.path() + "\\Unvanquished.lnk", linkName)) {
+    if (!CreateLink(installPath + "\\updater.exe", installPath, dir.path() + "\\Unvanquished.lnk", linkName)) {
         qDebug() << "Creating shortcut failed";
         return false;
     }

--- a/win.cpp
+++ b/win.cpp
@@ -288,7 +288,7 @@ bool startGame(const QString& commandLine)
 }
 
 // Care should be taken when using this function to avoid any possibility of an endless restart loop.
-// RelaunchElevated is skipped when --updateupdaterto or --updategame is used in order to avoid this.
+// RelaunchElevated is skipped when --update-updater-to or --update-game is used in order to avoid this.
 ElevationResult RelaunchElevated(const QString& flags)
 {
     if (Settings().testWrite() == QSettings::NoError) {


### PR DESCRIPTION
It is now possible to start the updater as non-admin. UAC elevation with a relaunched process is requested at the moment when an updater update is needed or the game update window is opened.