### PR TITLE
newscard: wordwrap the title

### DIFF
--- a/NewsCard.qml
+++ b/NewsCard.qml
@@ -129,8 +129,10 @@ Flickable {
                 TitleLabel {
                     id: title
 
+					width: parent.width
                     text: item.cardTitle
 
+                    wrapMode: Text.WordWrap
 					clip: true
                     font.pixelSize: 30
                     font.bold: true

--- a/NewsCard.qml
+++ b/NewsCard.qml
@@ -129,11 +129,11 @@ Flickable {
                 TitleLabel {
                     id: title
 
-					width: parent.width
+                    width: parent.width
                     text: item.cardTitle
 
                     wrapMode: Text.WordWrap
-					clip: true
+                    clip: true
                     font.pixelSize: 30
                     font.bold: true
                 }
@@ -141,7 +141,7 @@ Flickable {
                 BodyLabel {
                     id: summary
 
-					width: parent.width
+                    width: parent.width
                     wrapMode: Text.WordWrap
 
                     text: item.summary.substring(0, item.summary.search("<a"))
@@ -150,14 +150,14 @@ Flickable {
                     font.pixelSize: 21
                     lineHeight: 24
                     color: "lightgrey"
-				}
-			}
-		}
+                }
+            }
+        }
 
-		Rectangle {
+        Rectangle {
             anchors {
                 horizontalCenter: parent.horizontalCenter
-				bottom: parent.bottom
+                bottom: parent.bottom
             }
 
             width: parent.width - 15
@@ -166,17 +166,17 @@ Flickable {
             clip: true
             color: "transparent"
 
-			Column {
-				id: linkColumn
+            Column {
+                id: linkColumn
 
                 width: parent.width
                 height: parent.height
                 spacing: Units.smallSpacing * 2
 
-				BodyLabel {
-					id: link
+                BodyLabel {
+                    id: link
 
-					width: parent.width
+                    width: parent.width
 
                     text: "<p style='text-align: right;'><a style='color:#00B2B8;' href='" + item.url + "'>&rarr; Continue reading</a></p>"
                     textFormat: Text.RichText


### PR DESCRIPTION
Wordwrap the newscard title, also fix some whitespace

Before:

[![newscard](https://dl.illwieckz.net/b/unvanquished/updater/screenshots/newscard/20210121-153807-000.unvanquished-updater.png)](https://dl.illwieckz.net/b/unvanquished/updater/screenshots/newscard/20210121-153807-000.unvanquished-updater.png)

After:

[![newscard](https://dl.illwieckz.net/b/unvanquished/updater/screenshots/newscard/20210121-153932-000.unvanquished-updater.png)](https://dl.illwieckz.net/b/unvanquished/updater/screenshots/newscard/20210121-153932-000.unvanquished-updater.png)

Since I previously extracted the link from the summary to make sure it's always displayed on bottom, in worst case the summary is just truncated but the link works properly.
