### PR TITLE
Make Linux updater work with older libc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,16 @@ RUN make -j`nproc` && make install_sw && rm -rf /build-ssl
 # Build Qt #
 ############
 WORKDIR /build-qt
+# We set the results of the renameat2 and statx feature tests to failure with sed below, but the
+# statx test is actually ignored so this extra patch is needed to disable it.
+COPY disable-statx.patch .
 ENV UPDATER_MODULES=qtbase,qtquickcontrols,qtquickcontrols2,qtsvg,qtgraphicaleffects
 RUN curl -LO https://download.qt.io/archive/qt/5.14/5.14.2/single/qt-everywhere-src-5.14.2.tar.xz && \
     curl -L https://download.qt.io/archive/qt/5.14/5.14.2/single/md5sums.txt | md5sum --check --ignore-missing && \
     tar -xJf qt-everywhere-src-5.14.2.tar.xz && \
     cd qt-everywhere-src-5.14.2 && \
+    sed -i -E 's/tests[.](statx|renameat2)/false/' qtbase/src/corelib/configure.json && \
+    patch qtbase/src/corelib/io/qfilesystemengine_unix.cpp < ../disable-statx.patch && \
     OPENSSL_LIBS='-L/openssl/lib -lssl -lcrypto -lpthread -ldl' ./configure -opensource -confirm-license -release -optimize-size -no-shared -static --c++std=14 -nomake tests -nomake tools -nomake examples -no-gif -no-icu -no-glib -no-qml-debug -opengl desktop -no-eglfs -no-opengles3 -no-angle -no-egl -qt-xcb -xkbcommon -dbus-runtime -qt-freetype -qt-pcre -qt-harfbuzz -qt-libpng -qt-libjpeg -system-zlib -I /openssl/include -openssl-linked -prefix /qt && \
     bash -c "make -j`nproc` module-{$UPDATER_MODULES} && make module-{$UPDATER_MODULES}-install_subtargets" && \
     rm -rf /build-qt
@@ -64,6 +69,11 @@ RUN set -e; for D in . quazip fluid; do cd /updater2/$D && git clean -dXff; done
 WORKDIR /build
 RUN /qt/bin/qmake -config release QMAKE_LFLAGS+="-no-pie" /updater2 && make -j`nproc`
 RUN mv updater2 updater2-nonstripped && strip updater2-nonstripped -o updater2
+# Version check: do not depend on glibc > 2.26
+RUN echo GLIBC_2.26 > target_version && \
+    grep -aoE 'GLIBC_[0-9.]+' updater2 > symbol_versions && \
+    cat target_version symbol_versions | sort -V | tail -1 > max_version && \
+    diff -q target_version max_version
 ARG release
 RUN if [ -n "$release" ]; then cp updater2 UnvanquishedUpdater && 7z -tzip -mx=9 a UnvUpdaterLinux.zip UnvanquishedUpdater; fi
 ENV zipfile=${release:+UnvUpdaterLinux.zip}

--- a/disable-statx.patch
+++ b/disable-statx.patch
@@ -1,0 +1,15 @@
+--- qtbase/src/corelib/io/qfilesystemengine_unix.cpp	2020-03-27 04:49:31.000000000 -0500
++++ qtbase/src/corelib/io/qfilesystemengine_unix.cpp	2021-02-05 14:22:53.044477900 -0600
+@@ -95,12 +95,10 @@
+ #endif
+ #endif
+ 
+-#if defined(Q_OS_ANDROID)
+ // statx() is disabled on Android because quite a few systems
+ // come with sandboxes that kill applications that make system calls outside a
+ // whitelist and several Android vendors can't be bothered to update the list.
+ #  undef STATX_BASIC_STATS
+-#endif
+ 
+ #ifndef STATX_ALL
+ struct statx { mode_t stx_mode; };      // dummy


### PR DESCRIPTION
I guess we should merge this since there were 2 reports (#91 and #92), and it will probably be useful in the future, seeing how Qt also has the annoying behavior of enabling random features depending on whether they are present on the host machine.