### PR TITLE
Hide desktop files when the ~/.local/share/unvanquished directory has been removed

### DIFF
--- a/resources/net.unvanquished.Unvanquished.desktop
+++ b/resources/net.unvanquished.Unvanquished.desktop
@@ -6,6 +6,7 @@ Icon=unvanquished
 Terminal=false
 Type=Application
 Exec="%1/updater"
+TryExec="%1/updater"
 Categories=Game;ActionGame;StrategyGame;
 # Probably doesn't work since the updater is initially launched, not daemon
 PrefersNonDefaultGPU=true

--- a/resources/net.unvanquished.UnvanquishedProtocolHandler.desktop
+++ b/resources/net.unvanquished.UnvanquishedProtocolHandler.desktop
@@ -5,6 +5,7 @@ NoDisplay=true
 Terminal=false
 Type=Application
 Exec="%1/daemon" -connect %u
+TryExec="%1/daemon"
 MimeType=x-scheme-handler/unv
 # Unclear if this will work when Breakpad is enabled
 PrefersNonDefaultGPU=true


### PR DESCRIPTION
PR to be squashed with a proper message