### PR TITLE
Fix parsing HTML entities in blog title

### DIFF
--- a/NewsCard.qml
+++ b/NewsCard.qml
@@ -148,6 +148,7 @@ Flickable {
 
                     width: parent.width
                     text: item.cardTitle
+                    textFormat: Text.RichText
 
                     wrapMode: Text.WordWrap
                     clip: true


### PR DESCRIPTION
The title of a recent news post was displayed as "Looking for an OpenGL and C++ developer (let&#8217;s do portals!)"