### PR TITLE
Fix desktop file not showing up in application list (Linux)

### DIFF
--- a/resources/net.unvanquished.Unvanquished.desktop
+++ b/resources/net.unvanquished.Unvanquished.desktop
@@ -6,7 +6,7 @@ Icon=unvanquished
 Terminal=false
 Type=Application
 Exec="%1/updater"
-TryExec="%1/updater"
+TryExec=%1/updater
 Categories=Game;ActionGame;StrategyGame;
 # Probably doesn't work since the updater is initially launched, not daemon
 PrefersNonDefaultGPU=true

--- a/resources/net.unvanquished.UnvanquishedProtocolHandler.desktop
+++ b/resources/net.unvanquished.UnvanquishedProtocolHandler.desktop
@@ -5,7 +5,7 @@ NoDisplay=true
 Terminal=false
 Type=Application
 Exec="%1/daemon" -connect %u
-TryExec="%1/daemon"
+TryExec=%1/daemon
 MimeType=x-scheme-handler/unv
 # Unclear if this will work when Breakpad is enabled
 PrefersNonDefaultGPU=true


### PR DESCRIPTION
On my virtual machine GNOME is refusing to display desktop entries where TryExec is quoted. Indeed the spec only mentions quotes in Exec.

Regression in 5f9fe3ed5cd9b5ae135f615718b4767c1a571fe2.