### PR TITLE
Clean up command-line args and refactor QmlDownloader into 3 pieces

### DIFF
--- a/DownloadInfo.qml
+++ b/DownloadInfo.qml
@@ -178,7 +178,7 @@ Item {
         onClicked: {
             if (downloader.state === QmlDownloader.COMPLETED) {
                 root.close();
-                downloader.startGame();
+                gameLauncher.startGame(/*useConnectUrl=*/ false, /*failIfWindowsAdmin=*/ false);
                 return;
             }
             downloader.toggleDownload(selectedInstallPath);

--- a/gamelauncher.cpp
+++ b/gamelauncher.cpp
@@ -1,0 +1,71 @@
+/* Unvanquished Updater
+ * Copyright (C) Unvanquished Developers
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gamelauncher.h"
+
+#include <QDebug>
+#include <QMessageBox>
+#include <QRegularExpression>
+
+#include "system.h"
+
+static const QRegularExpression COMMAND_REGEX("%command%");
+
+GameLauncher::GameLauncher(const QString& connectUrl, const Settings& settings)
+    : connectUrl_(connectUrl), settings_(settings) {}
+
+// Does our version of daemon have -connect-trusted?
+static bool haveConnectTrusted(const QString& gameVersion)
+{
+    // Updater version up to v0.2.0 may set "unknown" as game version if versions.json request fails
+    if (gameVersion == "unknown")
+        return false;
+    // Hacky string comparison, assume we won't go down to 0.9 or up to 0.100 :)
+    return gameVersion > "0.54.1";
+}
+
+// Using the connect URL is optional because the updater intentionally "forgets about" the URL
+// if you go to the install screen.
+void GameLauncher::startGame(bool useConnectUrl, bool failIfWindowsAdmin)
+{
+    useConnectUrl = useConnectUrl && !connectUrl_.isEmpty();
+    QString gameCommand = Sys::getGameCommand(settings_.installPath());
+    QString commandLine;
+    if (useConnectUrl && !haveConnectTrusted(settings_.currentVersion())) {
+        // Behave for now as the old protocol handler which ignores the custom command
+        commandLine = gameCommand + " -connect " + connectUrl_;
+    } else {
+        commandLine = settings_.commandLine().trimmed();
+        if (!commandLine.contains(COMMAND_REGEX)) {
+            commandLine = "%command% " + commandLine;
+        }
+        if (useConnectUrl) {
+            gameCommand = gameCommand + " -connect-trusted " + connectUrl_;
+        }
+        commandLine.replace(COMMAND_REGEX, gameCommand);
+    }
+    qDebug() << "Starting game with command line:" << commandLine;
+    QString error = Sys::startGame(commandLine, failIfWindowsAdmin);
+    if (error.isEmpty()) {
+        qDebug() << "Game started successfully";
+    } else {
+        qDebug() << "Failed to start Unvanquished process:" << error;
+        QMessageBox errorMessageBox;
+        errorMessageBox.setText("Failed to start Unvanquished process: " + error);
+        errorMessageBox.exec();
+    }
+}

--- a/gamelauncher.h
+++ b/gamelauncher.h
@@ -1,0 +1,39 @@
+/* Unvanquished Updater
+ * Copyright (C) Unvanquished Developers
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef GAMELAUNCHER_H_
+#define GAMELAUNCHER_H_
+
+#include <QObject>
+#include <QString>
+#include "settings.h"
+
+class GameLauncher : public QObject
+{
+    Q_OBJECT
+
+private:
+    QString connectUrl_;
+    const Settings& settings_;
+
+public:
+    GameLauncher(const QString& connectUrl, const Settings& settings);
+
+    Q_INVOKABLE void startGame(bool useConnectUrl, bool failIfWindowsAdmin);
+};
+
+#endif // GAMELAUNCHER_H_

--- a/main.cpp
+++ b/main.cpp
@@ -60,8 +60,8 @@ struct CommandLineOptions {
     QString ariaLogFilename;
     int splashMilliseconds = 3000;
     QString updateUpdaterVersion;
-    bool updateGame;
-    bool playNow;
+    bool updateGame = false;
+    bool playNow = false;
     QString connectUrl;
 };
 
@@ -118,19 +118,15 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     ariaLogFilenameOption.setValueName("filename");
     QCommandLineOption splashMsOption("splashms");
     splashMsOption.setValueName("duration in milliseconds");
-    QCommandLineOption updateUpdaterOption("update-updater-to");
-    updateUpdaterOption.setValueName("updater version");
-    QCommandLineOption updateGameOption("update-game");
-    QCommandLineOption playNowOption("playnow");
+    QCommandLineOption internalCommandOption("internalcommand");
+    internalCommandOption.setValueName("command");
     QCommandLineParser optionParser;
     optionParser.addHelpOption();
     optionParser.addVersionOption();
     optionParser.addOption(logFileNameOption);
     optionParser.addOption(ariaLogFilenameOption);
     optionParser.addOption(splashMsOption);
-    optionParser.addOption(updateUpdaterOption);
-    optionParser.addOption(updateGameOption);
-    optionParser.addOption(playNowOption);
+    optionParser.addOption(internalCommandOption);
     optionParser.addPositionalArgument("URL", "address of Unvanquished server to connect to", "[URL]");
     optionParser.process(app);
     CommandLineOptions options;
@@ -141,9 +137,18 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
     if (splashMs > 0) {
         options.splashMilliseconds = splashMs;
     }
-    options.updateUpdaterVersion = optionParser.value(updateUpdaterOption);
-    options.updateGame = optionParser.isSet(updateGameOption);
-    options.playNow = optionParser.isSet(playNowOption);
+    if (optionParser.isSet(internalCommandOption)) {
+        QString command = optionParser.value(internalCommandOption);
+        if (command == "playnow") {
+            options.playNow = true;
+        } else if (command == "updategame") {
+            options.updateGame = true;
+        } else if (command.startsWith("updateupdater:")) {
+            options.updateUpdaterVersion = command.section(':', 1);
+        } else {
+            argParseError("Invalid --internalcommand option: " + command);
+        }
+    }
     return options;
 }
 

--- a/main.cpp
+++ b/main.cpp
@@ -30,6 +30,7 @@
 #include "iconsimageprovider.h"
 #include "iconthemeimageprovider.h"
 
+#include "gamelauncher.h"
 #include "qmldownloader.h"
 #include "settings.h"
 #include "system.h"
@@ -188,8 +189,11 @@ int main(int argc, char *argv[])
 
     app.setWindowIcon(QIcon(":resources/updater.png"));
 
+    Settings settings;
+    GameLauncher gameLauncher(options.connectUrl, settings);
+
     if (options.playNow) { // This is only used on Windows
-        StartGame(Settings(), options.connectUrl, true);
+        gameLauncher.startGame(/*useConnectUrl=*/ true, /*failIfWindowsAdmin=*/ true);
         return 0;
     }
 
@@ -201,7 +205,6 @@ int main(int argc, char *argv[])
         font.setPointSize(10);
         app.setFont(font);
     }
-    Settings settings;
     QmlDownloader downloader;
     downloader.ariaLogFilename_ = options.ariaLogFilename;
     downloader.connectUrl_ = options.connectUrl;
@@ -220,6 +223,7 @@ int main(int argc, char *argv[])
     engine.addImageProvider(QLatin1String("fluidicontheme"), new IconThemeImageProvider());
     auto* context = engine.rootContext();
     context->setContextProperty("updaterSettings", &settings);
+    context->setContextProperty("gameLauncher", &gameLauncher);
     context->setContextProperty("downloader", &downloader);
     context->setContextProperty("splashMilliseconds", options.splashMilliseconds);
     qmlRegisterType<QmlDownloader>("QmlDownloader", 1, 0, "QmlDownloader");

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -303,7 +303,7 @@ void QmlDownloader::autoLaunchOrUpdate()
         qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
         if (!forceUpdaterUpdate_) {
             // Remember the URL if we are doing only updater update
-            QString updaterArgs = "--splashms 1 --update-updater-to " + latestUpdaterVersion_;
+            QString updaterArgs = "--splashms 1 --internalcommand updateupdater:" + latestUpdaterVersion_;
             if (!connectUrl_.isEmpty()) {
                 updaterArgs += " -- " + connectUrl_;
             }
@@ -338,7 +338,7 @@ void QmlDownloader::autoLaunchOrUpdate()
                (!latestGameVersion_.isEmpty() && settings_.currentVersion() != latestGameVersion_)) {
         qDebug() << "Game update required.";
         connectUrl_.clear();
-        switch (Sys::RelaunchElevated("--splashms 1 --update-game")) {
+        switch (Sys::RelaunchElevated("--splashms 1 --internalcommand updategame")) {
             case Sys::ElevationResult::UNNEEDED:
                 break;
             case Sys::ElevationResult::RELAUNCHED:
@@ -358,7 +358,8 @@ void QmlDownloader::autoLaunchOrUpdate()
 bool QmlDownloader::relaunchForSettings()
 {
     qDebug() << "Possibly relaunching to open settings window";
-    return Sys::RelaunchElevated("--splashms 1 --update-game") != Sys::ElevationResult::UNNEEDED;
+    return Sys::RelaunchElevated("--splashms 1 --internalcommand updategame")
+        != Sys::ElevationResult::UNNEEDED;
 }
 
 QmlDownloader::DownloadState QmlDownloader::state() const

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -19,7 +19,6 @@
 #define QMLDOWNLOADER_H
 
 #include <QObject>
-#include <QRegularExpression>
 #include <QSettings>
 #include <QThread>
 #include <QUrl>
@@ -32,8 +31,6 @@
 #include "downloadworker.h"
 #include "downloadtimecalculator.h"
 #include "settings.h"
-
-void StartGame(const Settings& settings, const QString& connectUrl, bool failIfWindowsAdmin);
 
 class QmlDownloader : public QObject
 {
@@ -67,7 +64,7 @@ public:
     void forceGameUpdate();
 
     QString ariaLogFilename_;
-    QString connectUrl_;
+    QString connectUrl_; // used for updater update
 
 signals:
     void downloadSpeedChanged(int downloadSpeed);
@@ -90,7 +87,6 @@ public slots:
     void onCurrentVersions(QString updater, QString game);
 
     Q_INVOKABLE void toggleDownload(QString installPath);
-    Q_INVOKABLE void startGame();
     Q_INVOKABLE void autoLaunchOrUpdate();
     Q_INVOKABLE bool relaunchForSettings();
 

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -27,7 +27,6 @@
 #include <memory>
 #include <chrono>
 
-#include "currentversionfetcher.h"
 #include "downloadworker.h"
 #include "downloadtimecalculator.h"
 #include "settings.h"
@@ -59,9 +58,6 @@ public:
     int totalSize() const;
     int completedSize() const;
     DownloadState state() const;
-    void checkForUpdate();
-    void forceUpdaterUpdate(const QString& version);
-    void forceGameUpdate();
 
     QString ariaLogFilename_;
     QString connectUrl_; // used for updater update
@@ -74,9 +70,7 @@ signals:
     void completedSizeChanged(int completedSize);
     void statusMessage(QString message);
     void fatalMessage(QString message);
-    void updateNeeded(bool updateNeeded);
     void stateChanged(DownloadState state);
-    void updaterUpdate();
 
 public slots:
     void setDownloadSpeed(int speed);
@@ -84,11 +78,9 @@ public slots:
     void setTotalSize(int size);
     void setCompletedSize(int size);
     void onDownloadEvent(int event);
-    void onCurrentVersions(QString updater, QString game);
 
     Q_INVOKABLE void toggleDownload(QString installPath);
-    Q_INVOKABLE void autoLaunchOrUpdate();
-    Q_INVOKABLE bool relaunchForSettings();
+    Q_INVOKABLE void startUpdaterUpdate(QString version);
 
 private:
     void stopAria();
@@ -104,14 +96,9 @@ private:
     int totalSize_;
     int completedSize_;
 
-    CurrentVersionFetcher fetcher_;
     DownloadWorker* worker_;
     DownloadTimeCalculator downloadTime_;
     Settings settings_;
-    bool forceUpdaterUpdate_;
-    bool forceGameUpdate_;
-    QString latestGameVersion_;
-    QString latestUpdaterVersion_;
     DownloadState state_;
     std::unique_ptr<QTemporaryDir> temp_dir_;
 

--- a/splash.qml
+++ b/splash.qml
@@ -35,20 +35,18 @@ ApplicationWindow {
         running: true
         onTriggered: {
             settingsAction.enabled = false;
-            downloader.autoLaunchOrUpdate();
+            splashController.autoLaunchOrUpdate();
         }
     }
 
     function showUpdater() {
-        splashConnections.enabled = false;
+        splashDownloaderConnections.enabled = false;
         updaterWindowLoader.active = true
         splash.hide();
     }
 
     Connections {
-        id: splashConnections
-        target: downloader
-        ignoreUnknownSignals: true
+        target: splashController
 
         onUpdateNeeded: {  // game update only
             if (updateNeeded) {
@@ -60,6 +58,7 @@ ApplicationWindow {
         }
 
         onUpdaterUpdate: {
+            downloader.startUpdaterUpdate(version);
             updaterUpdateLabel.visible = true;
 
             // Now allow the window to go behind other windows in the z-order.
@@ -78,6 +77,11 @@ ApplicationWindow {
                 splash.flags &= ~Qt.WindowStaysOnTopHint;
             }
         }
+    }
+
+    Connections {
+        id: splashDownloaderConnections
+        target: downloader
 
         onFatalMessage: {
             updateFailed.errorDetail = message;
@@ -131,7 +135,7 @@ ApplicationWindow {
         onClicked: {
             timer.stop();
             settingsAction.enabled = false;
-            if (downloader.relaunchForSettings()) {
+            if (splashController.relaunchForSettings()) {
                 splash.close();
             } else {
                 showUpdater();

--- a/splash.qml
+++ b/splash.qml
@@ -55,7 +55,7 @@ ApplicationWindow {
                 showUpdater()
             } else {
                 splash.close();
-                downloader.startGame();
+                gameLauncher.startGame(/*useConnectUrl=*/ true, /*failIfWindowsAdmin=*/ false);
             }
         }
 

--- a/splashcontroller.cpp
+++ b/splashcontroller.cpp
@@ -1,0 +1,134 @@
+/* Unvanquished Updater
+ * Copyright (C) Unvanquished Developers
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "splashcontroller.h"
+
+#include <QCoreApplication>
+#include <QDebug>
+
+#include "system.h"
+
+SplashController::SplashController(
+    RelaunchCommand command, const QString& updateUpdaterVersion,
+    const QString& connectUrl, const Settings& settings) :
+        relaunchCommand_(command), updateUpdaterVersion_(updateUpdaterVersion),
+        connectUrl_(connectUrl), settings_(settings) {}
+
+// Possibly initiates an asynchronous request for the latest available versions.
+void SplashController::checkForUpdate()
+{
+    // Don't need versions.json if we already know what to do next
+    if (relaunchCommand_ != RelaunchCommand::NONE) {
+        return;
+    }
+
+    connect(&fetcher_, SIGNAL(onCurrentVersions(QString, QString)),
+            this, SLOT(onCurrentVersions(QString, QString)));
+    fetcher_.fetchCurrentVersion("https://dl.unvanquished.net/versions.json");
+}
+
+// Receives the results of the checkForUpdate request.
+void SplashController::onCurrentVersions(QString updater, QString game)
+{
+    latestUpdaterVersion_ = updater;
+    latestGameVersion_ = game;
+}
+
+// Return value is whether the program should exit
+bool SplashController::relaunchForSettings()
+{
+    qDebug() << "Possibly relaunching to open settings window";
+    return Sys::RelaunchElevated("--splashms 1 --internalcommand updategame")
+        != Sys::ElevationResult::UNNEEDED;
+}
+
+void SplashController::launchGameIfInstalled()
+{
+    if (settings_.currentVersion().isEmpty()) {
+        qDebug() << "No game installed, exiting";
+        QCoreApplication::quit();
+    } else {
+        qDebug() << "Fall back to launching installed game";
+        emit updateNeeded(false);
+    }
+}
+
+// This runs after the splash screen has been displayed for the programmed amount of time (and the
+// user did not click the settings button). If the CurrentVersionFetcher didn't emit anything yet,
+// proceed as if the request for versions.json failed.
+void SplashController::autoLaunchOrUpdate()
+{
+    qDebug() << "Previously-installed game version:" << settings_.currentVersion();
+
+    switch (relaunchCommand_) {
+        case RelaunchCommand::UPDATE_GAME:
+            qDebug() << "Game update menu requested as relaunch action";
+            // It is assumed the process is already elevated
+            emit updateNeeded(true);
+            return;
+
+        case RelaunchCommand::UPDATE_UPDATER:
+            qDebug() << "Updater update to" << updateUpdaterVersion_ << "requested as relaunch action";
+            // It is assumed the process is already elevated
+            emit updaterUpdate(updateUpdaterVersion_);
+            return;
+
+        case RelaunchCommand::PLAY_NOW:
+            // Should never happen
+
+        case RelaunchCommand::NONE:
+            break;
+    }
+
+    // If no relaunch action, detect update needed based on versions.json
+    if (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION)) {
+        qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
+        // Remember the URL if we are doing updater update
+        QString updaterArgs = "--splashms 1 --internalcommand updateupdater:" + latestUpdaterVersion_;
+        if (!connectUrl_.isEmpty()) {
+            updaterArgs += " -- " + connectUrl_;
+        }
+        switch (Sys::RelaunchElevated(updaterArgs)) {
+            case Sys::ElevationResult::UNNEEDED:
+                emit updaterUpdate(latestUpdaterVersion_);
+                return;
+            case Sys::ElevationResult::RELAUNCHED:
+                QCoreApplication::quit();
+                return;
+            case Sys::ElevationResult::FAILED:
+                launchGameIfInstalled();
+                return;
+        }
+    } else if (settings_.currentVersion().isEmpty() ||
+               (!latestGameVersion_.isEmpty() && settings_.currentVersion() != latestGameVersion_)) {
+        qDebug() << "Game update required.";
+        switch (Sys::RelaunchElevated("--splashms 1 --internalcommand updategame")) {
+            case Sys::ElevationResult::UNNEEDED:
+                emit updateNeeded(true);
+                return;
+            case Sys::ElevationResult::RELAUNCHED:
+                QCoreApplication::quit();
+                return;
+            case Sys::ElevationResult::FAILED:
+                launchGameIfInstalled();
+                return;
+        }
+    } else {
+        emit updateNeeded(false);
+    }
+}
+

--- a/splashcontroller.h
+++ b/splashcontroller.h
@@ -1,0 +1,75 @@
+/* Unvanquished Updater
+ * Copyright (C) Unvanquished Developers
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef SPLASHCONTROLLER_H_
+#define SPLASHCONTROLLER_H_
+
+#include <QObject>
+#include <QString>
+
+#include "currentversionfetcher.h"
+#include "settings.h"
+
+// These are used only on Windows where relaunching is needed for admin (de)elevation.
+enum class RelaunchCommand
+{
+    NONE,
+    PLAY_NOW,
+    UPDATE_GAME,
+    UPDATE_UPDATER,
+};
+
+// The SplashController decides what to do after the splash screen has been displayed for the
+// configured duration: update updater, go to game update, or start the game.
+// (TODO better name?)
+class SplashController : public QObject
+{
+    Q_OBJECT
+
+private:
+    // Actions from command line args
+    RelaunchCommand relaunchCommand_;
+    QString updateUpdaterVersion_; // If command is UPDATE_UPDATER
+    QString connectUrl_; // for pre-updater-update elevation
+
+    const Settings& settings_;
+
+    // Latest versions fetching
+    CurrentVersionFetcher fetcher_;
+    QString latestUpdaterVersion_;
+    QString latestGameVersion_;
+
+public:
+    SplashController(
+        RelaunchCommand command, const QString& updateUpdaterVersion,
+        const QString& connectUrl, const Settings& settings);
+    void checkForUpdate();
+    Q_INVOKABLE bool relaunchForSettings();
+    Q_INVOKABLE void autoLaunchOrUpdate();
+
+signals:
+    void updateNeeded(bool updateNeeded);
+    void updaterUpdate(QString version);
+
+private slots:
+    void onCurrentVersions(QString updater, QString game);
+
+private:
+    void launchGameIfInstalled();
+};
+
+#endif // SPLASHCONTROLLER_H_

--- a/updater2.pro
+++ b/updater2.pro
@@ -10,6 +10,7 @@ HEADERS += ariadownloader.h \
     gamelauncher.h \
     system.h \
     settings.h \
+    splashcontroller.h \
     qmldownloader.h \
     currentversionfetcher.h
 
@@ -21,6 +22,7 @@ SOURCES += ariadownloader.cpp \
     main.cpp \
     qmldownloader.cpp \
     settings.cpp \
+    splashcontroller.cpp \
     currentversionfetcher.cpp
 
 mac {

--- a/updater2.pro
+++ b/updater2.pro
@@ -7,6 +7,7 @@ CONFIG += c++11
 HEADERS += ariadownloader.h \
     downloadtimecalculator.h \
     downloadworker.h \
+    gamelauncher.h \
     system.h \
     settings.h \
     qmldownloader.h \
@@ -16,6 +17,7 @@ HEADERS += ariadownloader.h \
 SOURCES += ariadownloader.cpp \
     downloadtimecalculator.cpp \
     downloadworker.cpp \
+    gamelauncher.cpp \
     main.cpp \
     qmldownloader.cpp \
     settings.cpp \

--- a/win.cpp
+++ b/win.cpp
@@ -339,7 +339,7 @@ QString startGame(const QString& commandLine, bool failIfWindowsAdmin)
 
     // Relaunch the updater without elevation so that the graphics preference can be set.
     std::wstring program = QCoreApplication::applicationFilePath().toStdWString();
-    std::wstring args = L"--playnow";
+    std::wstring args = L"--internalcommand playnow";
     qDebug() << "restarting de-elevated: program =" << program << "args =" << args;
     HRESULT result = ShellExecInExplorerProcess(program.c_str(), args.c_str());
     qDebug() << "HRESULT:" << result;
@@ -355,7 +355,8 @@ QString startGame(const QString& commandLine, bool failIfWindowsAdmin)
 }
 
 // Care should be taken when using this function to avoid any possibility of an endless restart loop.
-// RelaunchElevated is skipped when --update-updater-to or --update-game is used in order to avoid this.
+// RelaunchElevated is skipped when internal commands updateupdater or updategame are used in
+// order to avoid this.
 ElevationResult RelaunchElevated(const QString& flags)
 {
     if (runningAsAdmin()) {

--- a/win.cpp
+++ b/win.cpp
@@ -338,6 +338,7 @@ QString startGame(const QString& commandLine, bool failIfWindowsAdmin)
     }
 
     // Relaunch the updater without elevation so that the graphics preference can be set.
+    // TODO: propagate connect URL in this case
     std::wstring program = QCoreApplication::applicationFilePath().toStdWString();
     std::wstring args = L"--internalcommand playnow";
     qDebug() << "restarting de-elevated: program =" << program << "args =" << args;


### PR DESCRIPTION
Combine 3 command-line args which are mutually exclusive and not intended for the end user into the `--internalcommand` argument.

Break qmldownloader.cpp into 3 parts. A GameLauncher takes the code for starting the game process; a SplashController for deciding what to do at the splash screen (whether an update is needed); and finally QmlDownloader keeps the downloading responsibilities.

TODO: test on Linux. So far I tested on Windows.