### PR TITLE
Linux: store QSettings in a single location

### DIFF
--- a/linux.cpp
+++ b/linux.cpp
@@ -270,10 +270,16 @@ std::string getCertStore()
     return "";
 }
 
+void initApplicationName()
+{
+    QCoreApplication::setOrganizationName("unvanquished");
+    QCoreApplication::setApplicationName("updater");
+}
+
 // Settings are stored in ~/.config/unvanquished/updater.conf
 QSettings* makePersistentSettings(QObject* parent)
 {
-    return new QSettings("unvanquished", "updater", parent);
+    return new QSettings(parent);
 }
 
 QString getGameCommand(const QString& installPath)

--- a/main.cpp
+++ b/main.cpp
@@ -158,9 +158,8 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
 
 int main(int argc, char *argv[])
 {
-    QCoreApplication::setApplicationName("Unvanquished Updater");
+    Sys::initApplicationName();
     QCoreApplication::setApplicationVersion(GIT_VERSION);
-    QCoreApplication::setOrganizationName("Unvanquished Development");
     QCoreApplication::setOrganizationDomain("unvanquished.net");
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication app(argc, argv);

--- a/osx.cpp
+++ b/osx.cpp
@@ -173,6 +173,12 @@ std::string getCertStore()
     return "";  // Not used on OSX.
 }
 
+void initApplicationName()
+{
+    QCoreApplication::setOrganizationName("Unvanquished Development");
+    QCoreApplication::setApplicationName("Unvanquished Updater");
+}
+
 // Settings are stored in "~/Library/Preferences/net.unvanquished.Unvanquished Updater.plist"
 // After deleting/changing the file, you must run `sudo killall cfprefsd` for it to take effect
 QSettings* makePersistentSettings(QObject* parent)

--- a/system.h
+++ b/system.h
@@ -26,6 +26,7 @@
 namespace Sys {
 QString archiveName();
 QString defaultInstallPath();
+void initApplicationName(); // influences default storage location for QSettings
 bool validateInstallPath(const QString& installPath); // Checks installing as root in homepath on Linux
 bool installShortcuts(); // Install launch menu entries and protocol handlers
 bool installUpdater(const QString& installPath); // Copies current application to <install path>/updater[.exe|.app]

--- a/win.cpp
+++ b/win.cpp
@@ -295,11 +295,20 @@ std::string getCertStore()
     return "";  // Not used on Windows.
 }
 
+void initApplicationName()
+{
+    QCoreApplication::setOrganizationName("Unvanquished Development");
+    QCoreApplication::setApplicationName("Unvanquished Updater");
+}
+
 // Settings are stored in the registry at (on 64-bit Windows)
 // HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Unvanquished Development\Unvanquished Updater
 // ≤v0.0.5 used HKEY_CURRENT_USER\Software\Unvanquished Development\Unvanquished Updater
+// Note: a class that we use, QQControlsFileDialog, creates some of its own registry entries
+// at HKEY_CURRENT_USER\SOFTWARE\Unvanquished Development\Unvanquished Updater
 QSettings* makePersistentSettings(QObject* parent)
 {
+    // We install to Program Files by default, so use global rather than per-user settings.
     return new QSettings(QSettings::SystemScope, parent);
 }
 


### PR DESCRIPTION
Fixes the Linux part of #121. Choose the location of our settings by changing the default location for settings, rather than customizing the parameter of our settings object. This makes it so the settings added by a component we depend on end up in the same place.