### PR TITLE
Toggle or stop download thread-safely

### DIFF
--- a/ariadownloader.cpp
+++ b/ariadownloader.cpp
@@ -20,6 +20,12 @@
 #include "ariadownloader.h"
 #include "system.h"
 
+// libaria2 thread safety note:
+// "Please keep in mind that only one Session object can be allowed per process due to the heavy use
+// of static objects in aria2 code base. Session object is not safe for concurrent accesses from
+// multiple threads. It must be used from one thread at a time. In general, libaria2 is not entirely
+// thread-safe."
+
 int downloadEventCallback(aria2::Session* session, aria2::DownloadEvent event,
                           aria2::A2Gid gid, void* userData)
 {

--- a/downloadworker.h
+++ b/downloadworker.h
@@ -40,11 +40,11 @@ public:
     void addTorrent(const std::string& uri);
     void setDownloadDirectory(const std::string& dir);
     void setConnectUrl(const QString& url);
-    void toggle();
-    void stop();
 
 public slots:
     void download();
+    void toggle();
+    void stop();
 
 signals:
     void downloadSpeedChanged(int speed);

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -18,6 +18,7 @@
 #include <QDir>
 #include <QApplication>
 #include <QDebug>
+#include <QMetaObject>
 
 #include "qmldownloader.h"
 #include "system.h"
@@ -181,7 +182,7 @@ void QmlDownloader::toggleDownload(QString installPath)
         startUpdate(installPath);
         return;
     }
-    worker_->toggle();
+    QMetaObject::invokeMethod(worker_, "toggle");
     setState(state() == DOWNLOADING ? PAUSED : DOWNLOADING);
 }
 
@@ -189,7 +190,7 @@ void QmlDownloader::stopAria()
 {
     if (worker_) {
         qDebug() << "Stopping downloader thread";
-        worker_->stop();
+        QMetaObject::invokeMethod(worker_, "stop");
         thread_.quit();
         thread_.wait();
         worker_ = nullptr;


### PR DESCRIPTION
The download loop which downloads using libaria2 runs in a secondary thread. The downloader's toggle and stop functions were called from the main thread. The 'stop' case was probably harmless in practice, but the toggle case manipulates the aria objects which are concurrently used by the download thread in a dangerous way.

Fix this by defining toggle and stop as signals which are sent to the downloader thread, and have the download loop manually check the thread's event queue.
