### PR TITLE
Minor cleanup with QmlDownloader and qmlRegisterType 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -211,9 +211,7 @@ int main(int argc, char *argv[])
     SplashController splashController(
         options.relaunchCommand, options.updateUpdaterVersion, options.connectUrl, settings);
     splashController.checkForUpdate();
-    QmlDownloader downloader;
-    downloader.ariaLogFilename_ = options.ariaLogFilename;
-    downloader.connectUrl_ = options.connectUrl;
+    QmlDownloader downloader(options.ariaLogFilename, options.connectUrl, settings);
     QQmlApplicationEngine engine;
     engine.addImportPath(QLatin1String("qrc:/"));
     engine.addImageProvider(QLatin1String("fluidicons"), new IconsImageProvider());
@@ -224,7 +222,10 @@ int main(int argc, char *argv[])
     context->setContextProperty("splashController", &splashController);
     context->setContextProperty("downloader", &downloader);
     context->setContextProperty("splashMilliseconds", options.splashMilliseconds);
-    qmlRegisterType<QmlDownloader>("QmlDownloader", 1, 0, "QmlDownloader");
+
+    // This is done in order to use the DownloadState enum
+    qmlRegisterUncreatableType<QmlDownloader>(
+        "QmlDownloader", 1, 0, "QmlDownloader", "QmlDownloader not constructible");
 
     engine.load(QUrl(QLatin1String("qrc:/splash.qml")));
     return app.exec();

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -24,7 +24,11 @@
 
 static const QString UPDATER_BASE_URL("https://github.com/Unvanquished/updater/releases/download");
 
-QmlDownloader::QmlDownloader() : downloadSpeed_(0),
+QmlDownloader::QmlDownloader(QString ariaLogFilename, QString connectUrl, Settings& settings) :
+        ariaLogFilename_(ariaLogFilename),
+        connectUrl_(connectUrl),
+        settings_(settings),
+        downloadSpeed_(0),
         uploadSpeed_(0),
         eta_(0),
         totalSize_(0),

--- a/qmldownloader.h
+++ b/qmldownloader.h
@@ -50,7 +50,7 @@ public:
     };
     Q_ENUM(DownloadState)
 
-    QmlDownloader();
+    QmlDownloader(QString ariaLogFilename, QString connectUrl, Settings& settings);
     ~QmlDownloader();
     int downloadSpeed() const;
     int uploadSpeed() const;
@@ -58,9 +58,6 @@ public:
     int totalSize() const;
     int completedSize() const;
     DownloadState state() const;
-
-    QString ariaLogFilename_;
-    QString connectUrl_; // used for updater update
 
 signals:
     void downloadSpeedChanged(int downloadSpeed);
@@ -89,6 +86,10 @@ private:
     void startUpdate(const QString& selectedInstallPath);
     void launchGameIfInstalled();
 
+    QString ariaLogFilename_;
+    QString connectUrl_; // used for updater update
+    Settings& settings_;
+
     QThread thread_;
     int downloadSpeed_;
     int uploadSpeed_;
@@ -98,7 +99,6 @@ private:
 
     DownloadWorker* worker_;
     DownloadTimeCalculator downloadTime_;
-    Settings settings_;
     DownloadState state_;
     std::unique_ptr<QTemporaryDir> temp_dir_;
 


### PR DESCRIPTION
Pass stuff in QmlDownloader constructor instead of setting members directly. The qmlRegisterType thing needed to be tweaked so that it doesn't require a default constructor to exist.