### PR TITLE
Linux: set the X11 WMCLASS for its own windows

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -162,6 +162,11 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationVersion(GIT_VERSION);
     QCoreApplication::setOrganizationDomain("unvanquished.net");
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+
+    /* Set the WMCLASS, similar to the --name=WMCLASS command line option.
+    See: https://github.com/Unvanquished/updater/pull/142 */
+    qputenv("RESOURCE_NAME", "net.unvanquished.Unvanquished");
+
     QApplication app(argc, argv);
 
     // The font is already needed to display our arg parsing error on Linux


### PR DESCRIPTION
- Set the Updater window WMCLASS

---

Original message:

- Set the WMCLASS in the XDG desktop file
- Set the Updater window WMCLASS
- Tell the XDG desktop file this application cannot run multiple instances.
- Add “Run” and “Update” options to the XDG dekstop file
  * The “Run” option runs the engine without checking for any updates.
  * The “Update” option force the display of the game downloader,
  like when clicking on the gear icon on the splash.

See DaemonEngine/Daemon#1702 for details about the WMCLASS thing:

- https://github.com/DaemonEngine/Daemon/pull/1702