### PR TITLE
Set desktop file name for WM_CLASS

### DIFF
--- a/linux.cpp
+++ b/linux.cpp
@@ -22,6 +22,7 @@
 #include <QDir>
 #include <QDebug>
 #include <QCoreApplication>
+#include <QGuiApplication>
 #include <QProcess>
 #include <QRegularExpression>
 #include <QStandardPaths>
@@ -30,6 +31,8 @@
 namespace Sys {
 
 namespace {
+
+const QString DESKTOP_FILE_NAME = "net.unvanquished.Unvanquished.desktop";
 
 // Use QProcess::splitCommand in Qt 5.15+
 QStringList splitArgs(const QString& command) {
@@ -155,15 +158,14 @@ bool installShortcuts()
         qDebug() << "Created directory for desktop files" << desktopDirString;
     }
 
-    QString desktopFileName = "net.unvanquished.Unvanquished.desktop";
-    QFile desktopFile(":resources/" + desktopFileName);
+    QFile desktopFile(":resources/" + DESKTOP_FILE_NAME);
     if (!desktopFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qDebug() << "missing resource" << desktopFileName;
+        qDebug() << "missing resource" << DESKTOP_FILE_NAME;
         return false;
     }
     QString desktopStr = QString(desktopFile.readAll().data()).arg(settings.installPath());
     {
-        QFile outputFile(desktopDir.filePath(desktopFileName));
+        QFile outputFile(desktopDir.filePath(DESKTOP_FILE_NAME));
         if (!outputFile.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
             qDebug() << "error opening" << outputFile.fileName();
             return false;
@@ -177,7 +179,7 @@ bool installShortcuts()
 
     int ret = QProcess::execute("xdg-mime",
                                 {QString("default"),
-                                 desktopDir.filePath(desktopFileName),
+                                 desktopDir.filePath(DESKTOP_FILE_NAME),
                                  QString("x-scheme-handler/unv")});
     qDebug() << "xdg-mime returned" << ret;
     ret = QProcess::execute("update-desktop-database", {desktopDirString});
@@ -289,6 +291,9 @@ void initApplicationName()
 {
     QCoreApplication::setOrganizationName("unvanquished");
     QCoreApplication::setApplicationName("updater");
+
+    // for Wayland backend
+    QGuiApplication::setDesktopFileName(DESKTOP_FILE_NAME);
 }
 
 // Settings are stored in ~/.config/unvanquished/updater.conf

--- a/linux.cpp
+++ b/linux.cpp
@@ -292,7 +292,9 @@ void initApplicationName()
     QCoreApplication::setOrganizationName("unvanquished");
     QCoreApplication::setApplicationName("updater");
 
-    // for Wayland backend
+    // WM_CLASS for X backend
+    qputenv("RESOURCE_NAME", "net.unvanquished.Unvanquished");
+    // equivalent for Wayland backend
     QGuiApplication::setDesktopFileName(DESKTOP_FILE_NAME);
 }
 


### PR DESCRIPTION
See the `Linux: Set the Updater window WMCLASS` commit from #142. This is a version using the Qt API instead of environment variables. Note that I have not tested it since I don't know how to observe any consequences of a WM_CLASS change.

Also I replaced references to `QApplication` with the more precise `QGuiApplication` so we won't have references to 3 different application classes.