### PR TITLE
Linux: Add “RunWithoutUpdate” and “Update” actions to the XDG desktop file

### DIFF
--- a/resources/net.unvanquished.Unvanquished.desktop
+++ b/resources/net.unvanquished.Unvanquished.desktop
@@ -13,3 +13,12 @@ StartupWMClass=net.unvanquished.Unvanquished
 SingleMainWindow=true
 # Probably doesn't work since the updater is initially launched, not daemon
 PrefersNonDefaultGPU=true
+Actions=RunWithoutUpdate;Update;
+
+[Desktop Action RunWithoutUpdate]
+Name=Open the game without checking for updates
+Exec=%1/updater --internalcommand playnow
+
+[Desktop Action Update]
+Name=Open the game updater
+Exec=%1/updater --internalcommand updategame


### PR DESCRIPTION
Add “RunWithoutUpdate” and “Update” actions to the XDG desktop file:

- The “RunWithoutUpdate” action runs the engine without checking for any updates.
- The “Update” action force the display of the game downloader, like when clicking on the gear icon on the splash.

Extracted from:

- https://github.com/Unvanquished/updater/pull/142