### PR TITLE
Linux: add the “Shooter” category in the XDG desktop file

### DIFF
--- a/resources/net.unvanquished.Unvanquished.desktop
+++ b/resources/net.unvanquished.Unvanquished.desktop
@@ -8,7 +8,7 @@ Type=Application
 Exec="%1/updater" -- %u
 TryExec=%1/updater
 MimeType=x-scheme-handler/unv
-Categories=Game;ActionGame;StrategyGame;
+Categories=Game;ActionGame;StrategyGame;Shooter;
 StartupWMClass=net.unvanquished.Unvanquished
 SingleMainWindow=true
 # Probably doesn't work since the updater is initially launched, not daemon


### PR DESCRIPTION
Linux: add the “Shooter” category in the XDG desktop file

It's already done in the flatpak XDG desktop file, so this reduce diff noise between the twos.