### PR TITLE
Implement `--internalcommand update` to check for both updater and game update

### DIFF
--- a/downloadworker.cpp
+++ b/downloadworker.cpp
@@ -84,7 +84,7 @@ void DownloadWorker::onDownloadCallback(aria2::Session* session, aria2::Download
                 }
                 auto files = handle->getFiles();
                 qDebug() << "Downloaded updater at" << files[0].path.c_str();
-                Sys::updateUpdater(QString(files[0].path.c_str()), connectUrl_);
+                Sys::updateUpdater(QString(files[0].path.c_str()), connectUrl_, updateGame_);
                 return;
             } else {
                 // For a torrent, happens when aria2 is stopped
@@ -200,6 +200,11 @@ void DownloadWorker::setDownloadDirectory(const std::string& dir)
 void DownloadWorker::setConnectUrl(const QString& url)
 {
     connectUrl_ = url;
+}
+
+void DownloadWorker::setGameUpdate(bool updateGame)
+{
+    updateGame_ = updateGame;
 }
 
 void DownloadWorker::stop()

--- a/downloadworker.h
+++ b/downloadworker.h
@@ -40,6 +40,7 @@ public:
     void addTorrent(const std::string& uri);
     void setDownloadDirectory(const std::string& dir);
     void setConnectUrl(const QString& url);
+    void setGameUpdate(bool);
 
 public slots:
     void download();
@@ -76,6 +77,7 @@ private:
     QString downloadDir_;
     QString unvanquishedVersion_; // determined from path names in the download
     QString connectUrl_;
+    bool updateGame_;
 };
 
 #endif // DOWNLOADWORKER_H

--- a/linux.cpp
+++ b/linux.cpp
@@ -214,7 +214,7 @@ bool installUpdater(const QString& installPath) {
            // Yes it is really supposed to be 0x775 not 0775
 }
 
-bool updateUpdater(const QString& updaterArchive, const QString& connectUrl)
+bool updateUpdater(const QString& updaterArchive, const QString& connectUrl, bool updateGame)
 {
     QString current = QCoreApplication::applicationFilePath();
     QString backup = current + ".bak";
@@ -254,6 +254,9 @@ bool updateUpdater(const QString& updaterArchive, const QString& connectUrl)
 
     QStringList args;
     args << current;
+    if (updateGame) {
+        args << "--internalcommand" << "updategame";
+    }
     if (!connectUrl.isEmpty()) {
         args << "--" << connectUrl;
     }

--- a/main.cpp
+++ b/main.cpp
@@ -142,6 +142,8 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
         QString command = optionParser.value(internalCommandOption);
         if (command == "playnow") {
             options.relaunchCommand = RelaunchCommand::PLAY_NOW;
+        } else if (command == "update") {
+            options.relaunchCommand = RelaunchCommand::UPDATE_ALL;
         } else if (command == "updategame") {
             options.relaunchCommand = RelaunchCommand::UPDATE_GAME;
         } else if (command.startsWith("updateupdater:")) {

--- a/osx.cpp
+++ b/osx.cpp
@@ -105,7 +105,7 @@ bool installUpdater(const QString& installPath) {
     return ret == 0;
 }
 
-bool updateUpdater(const QString& updaterArchive, const QString&)
+bool updateUpdater(const QString& updaterArchive, const QString&, bool)
 {
     QString currentAppPath = extractAppPath(QCoreApplication::applicationFilePath());
     if (currentAppPath.isEmpty()) return false;

--- a/qmldownloader.cpp
+++ b/qmldownloader.cpp
@@ -203,12 +203,22 @@ void QmlDownloader::stopAria()
 
 void QmlDownloader::startUpdaterUpdate(QString version)
 {
+    QString withGame = ":withgame";
+    bool updateGame = version.endsWith(withGame);
+
+    if (updateGame) {
+        version = version.left(version.length() - withGame.length());
+    }
+
     QString url = UPDATER_BASE_URL + "/" + version + "/" + Sys::updaterArchiveName();
+    qDebug() << "Downloading updater" << version << "from" << url;
+
     temp_dir_.reset(new QTemporaryDir());
     worker_ = new DownloadWorker(ariaLogFilename_);
     worker_->setDownloadDirectory(QDir(temp_dir_->path()).canonicalPath().toStdString());
     worker_->setConnectUrl(connectUrl_);
     worker_->addUpdaterUri(url.toStdString());
+    worker_->setGameUpdate(updateGame);
     worker_->moveToThread(&thread_);
     connect(&thread_, SIGNAL(finished()), worker_, SLOT(deleteLater()));
     connect(worker_, SIGNAL(onDownloadEvent(int)), this, SLOT(onDownloadEvent(int)));

--- a/splashcontroller.cpp
+++ b/splashcontroller.cpp
@@ -74,7 +74,13 @@ void SplashController::autoLaunchOrUpdate()
 {
     qDebug() << "Previously-installed game version:" << settings_.installedVersion();
 
+    QString withGame = relaunchCommand_ == RelaunchCommand::UPDATE_ALL ? ":withgame" : "";
+
     switch (relaunchCommand_) {
+        case RelaunchCommand::UPDATE_ALL:
+            // Done below.
+            break;
+
         case RelaunchCommand::UPDATE_GAME:
             qDebug() << "Game update menu requested as relaunch action";
             // It is assumed the process is already elevated
@@ -84,7 +90,7 @@ void SplashController::autoLaunchOrUpdate()
         case RelaunchCommand::UPDATE_UPDATER:
             qDebug() << "Updater update to" << updateUpdaterVersion_ << "requested as relaunch action";
             // It is assumed the process is already elevated
-            emit updaterUpdate(updateUpdaterVersion_);
+            emit updaterUpdate(updateUpdaterVersion_ + withGame);
             return;
 
         case RelaunchCommand::PLAY_NOW:
@@ -98,16 +104,16 @@ void SplashController::autoLaunchOrUpdate()
     if (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION)) {
         qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
         // Remember the URL if we are doing updater update
-        QString updaterArgs = "--splashms 1 --internalcommand updateupdater:" + latestUpdaterVersion_;
+        QString updaterArgs = "--splashms 1 --internalcommand updateupdater:" + latestUpdaterVersion_ + withGame;
         if (!connectUrl_.isEmpty()) {
             updaterArgs += " -- " + connectUrl_;
         }
         switch (Sys::RelaunchElevated(updaterArgs)) {
             case Sys::ElevationResult::UNNEEDED:
-                emit updaterUpdate(latestUpdaterVersion_);
+                emit updaterUpdate(latestUpdaterVersion_ + withGame);
                 return;
             case Sys::ElevationResult::RELAUNCHED:
-                QCoreApplication::quit();
+            QCoreApplication::quit();
                 return;
             case Sys::ElevationResult::FAILED:
                 launchGameIfInstalled();
@@ -127,6 +133,8 @@ void SplashController::autoLaunchOrUpdate()
                 launchGameIfInstalled();
                 return;
         }
+    } else if (relaunchCommand_ == RelaunchCommand::UPDATE_ALL) {
+        emit updateNeeded(true);
     } else {
         emit updateNeeded(false);
     }

--- a/splashcontroller.h
+++ b/splashcontroller.h
@@ -29,6 +29,7 @@ enum class RelaunchCommand
 {
     NONE,
     PLAY_NOW,
+    UPDATE_ALL,
     UPDATE_GAME,
     UPDATE_UPDATER,
 };

--- a/system.h
+++ b/system.h
@@ -30,7 +30,7 @@ void initApplicationName(); // influences default storage location for QSettings
 bool validateInstallPath(const QString& installPath); // Checks installing as root in homepath on Linux
 bool installShortcuts(); // Install launch menu entries and protocol handlers
 bool installUpdater(const QString& installPath); // Copies current application to <install path>/updater[.exe|.app]
-bool updateUpdater(const QString& updaterArchive, const QString& connectUrl);
+bool updateUpdater(const QString& updaterArchive, const QString& connectUrl, bool updateGame);
 QString updaterArchiveName();
 std::string getCertStore();
 QSettings* makePersistentSettings(QObject* parent);

--- a/win.cpp
+++ b/win.cpp
@@ -234,7 +234,7 @@ bool installUpdater(const QString& installPath) {
     return QFile::copy(src.absoluteFilePath(), dest.filePath());
 }
 
-bool updateUpdater(const QString& updaterArchive, const QString& connectUrl)
+bool updateUpdater(const QString& updaterArchive, const QString& connectUrl, bool updateGame)
 {
     QString current = QCoreApplication::applicationFilePath();
     QString backup = current + ".bak";
@@ -273,6 +273,9 @@ bool updateUpdater(const QString& updaterArchive, const QString& connectUrl)
     }
 
     QStringList args;
+    if (updateGame) {
+        args << "--internalcommand" << "updategame";
+    }
     if (!connectUrl.isEmpty()) {
         args << "--" << connectUrl;
     }


### PR DESCRIPTION
Implement `--internalcommand update` to check for both updater and game update.

Required by:

- https://github.com/Unvanquished/updater/pull/150

I haven't tested the game being updated after an updater being updated because when downloading a new updater I'm not testing my code anymore.

The “game update being requested by the updater after an updater update and relaunch” feature isn't implemented on macOS, because relaunching the updater with args doesn't look to be implemented to begin with. It would still check for an updater update, and it would still open the game update windows if there is no updater update, it will just act as always (run the game if there is no update) after an updater update.