### PR TITLE
Link the updater with OpenSSL explicitely, only link Aria2 with OpenSSL as crypto library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY aria2 /updater/aria2
 COPY .git/modules/aria2 /updater/.git/modules/aria2
 WORKDIR /updater/aria2
 RUN git clean -dXff
-RUN autoreconf -i && OPENSSL_LIBS='-L/openssl/lib64 -lssl -lcrypto -lpthread -ldl' OPENSSL_CFLAGS='-I /openssl/include' ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-zlib --without-libcares --enable-static --disable-shared --without-libssh2 --disable-metalink --disable-websocket --disable-nls --with-openssl && make -j`nproc`
+RUN autoreconf -i && OPENSSL_LIBS='-L/openssl/lib64 -lssl -lcrypto -lpthread -ldl' OPENSSL_CFLAGS='-I /openssl/include' ./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-zlib --without-libcares --enable-static --disable-shared --without-libssh2 --disable-metalink --disable-websocket --disable-nls --with-openssl --without-gnutls --without-nettle && make -j`nproc`
 
 #################
 # Build updater #

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before building the updater itself you need to build aria2 library
 ```
 cd aria2
 autoreconf -i
-./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-zlib --without-libcares --enable-static --disable-shared --without-libssh2 --disable-metalink --disable-websocket --disable-nls --with-openssl
+./configure --without-libxml2 --without-libexpat --without-sqlite3 --enable-libaria2 --without-zlib --without-libcares --enable-static --disable-shared --without-libssh2 --disable-metalink --disable-websocket --disable-nls --with-openssl --without-gnutls --without-nettle
 make -j4
 cd ..
 ```

--- a/updater.pro
+++ b/updater.pro
@@ -44,7 +44,7 @@ RESOURCES += qml.qrc
 
 win32:LIBS += $$PWD/aria2/src/.libs/libaria2.a
 win32:LIBS += -lcrypt32 -lsecur32 -lole32
-unix:LIBS += -lz "-L$$PWD/aria2/src/.libs" -laria2
+unix:LIBS += -lz "-L$$PWD/aria2/src/.libs" -laria2 -lssl -lcrypto
 
 win32:RC_FILE = updater.rc
 


### PR DESCRIPTION
- Link the updater with OpenSSL explicitely

On my end, outside of  Docker, I need those linker flags.

- Only link Aria2 with OpenSSL as crypto library

Useful instructions in the README to avoid linking with many crypto libraries in our back.
Does the same in Docker just in case.