### PR TITLE
Disable some OpenSSL features in the Linux build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN curl -LO https://github.com/openssl/openssl/releases/download/openssl-3.6.0/
     curl -L https://github.com/openssl/openssl/releases/download/openssl-3.6.0/openssl-3.6.0.tar.gz.sha256 | sha256sum --check
 RUN tar -xzf openssl-3.6.0.tar.gz
 WORKDIR /build-ssl/openssl-3.6.0
-RUN ./config no-shared --prefix=/openssl
+RUN ./config --prefix=/openssl --openssldir=/dev/null no-shared no-apps no-autoload-config no-capieng no-dso no-dynamic-engine no-engine no-loadereng no-module
 RUN make -j`nproc` && make install_sw && rm -rf /build-ssl
 
 ############


### PR DESCRIPTION
In the Linux Docker build, disable OpenSSL configure options that sound like they could potentially be related to opening shared libraries at runtime. Investigating #155, we found that it tries to look for and open some shared libraries in the configured install path.

Also set this path to "/dev/null" since it still tries to open a configuration file from there.

Fixes #155 (error in aria2 when using OpenSSL's random function).