### PR TITLE
QML cleanup (preparing for Qt 6)

### DIFF
--- a/DownloadInfo.qml
+++ b/DownloadInfo.qml
@@ -18,8 +18,8 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.0
-import Fluid.Controls 1.0
-import Fluid.Material 1.0
+import Fluid.Controls 1.0 as FluidControls
+import Fluid.Material 1.0 as FluidMaterial
 import QmlDownloader 1.0
 import "utils.js" as Utils
 
@@ -33,7 +33,7 @@ Item {
         bottomMargin: 60
     }
 
-    Card {
+    FluidControls.Card {
         anchors {
             right: parent.right
         }
@@ -50,7 +50,7 @@ Item {
             width: parent.width
             height: parent.height
 
-            BodyLabel {
+            FluidControls.BodyLabel {
                 id: instruction
 
                 anchors {
@@ -85,70 +85,70 @@ Item {
 
                 visible: false
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     width: 5
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: completedDownload
                     text: Utils.humanSize(downloader.completedSize)
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     text: " / "
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: totalDownload
                     text: Utils.humanSize(downloader.totalSize)
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     width: 20
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: eta
                     text: Utils.humanTime(downloader.eta)
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     width: 20
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     text: "DL: "
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: downloadSpeed
                     text: Utils.humanSize(downloader.downloadSpeed)
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     width: 20
                     text: "/s"
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     text: "UL: "
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: uploadSpeed
                     text: Utils.humanSize(downloader.uploadSpeed)
                     font.pixelSize: 17
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     text: "/s"
                     font.pixelSize: 17
                 }
@@ -156,7 +156,7 @@ Item {
         }
     }
 
-    ActionButton {
+    FluidMaterial.ActionButton {
         id: downloadAction
 
         anchors {

--- a/DownloadInfo.qml
+++ b/DownloadInfo.qml
@@ -189,7 +189,7 @@ Item {
         target: downloader
         ignoreUnknownSignals: true
 
-        onStateChanged: {
+        function onStateChanged(state) {
             downloadInfo.visible = state !== QmlDownloader.COMPLETED;
             if (state === QmlDownloader.DOWNLOADING) {
                 downloadAction.iconName = "av/pause";

--- a/News.qml
+++ b/News.qml
@@ -18,8 +18,8 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.1
 import QtQuick.Controls.Material 2.0
-import Fluid.Controls 1.0
-import Fluid.Material 1.0
+import Fluid.Controls 1.0 as FluidControls
+import Fluid.Material 1.0 as FluidMaterial
 
 Item {
     width: parent.width
@@ -142,7 +142,7 @@ Item {
         }
     }
 
-    ActionButton {
+    FluidMaterial.ActionButton {
         id: leftButton
 
         anchors.left: parent.left
@@ -157,7 +157,7 @@ Item {
         opacity: enabled ? 1 : 0.38
     }
 
-    ActionButton {
+    FluidMaterial.ActionButton {
         id: rightButton
 
         anchors.right: parent.right

--- a/NewsCard.qml
+++ b/NewsCard.qml
@@ -201,9 +201,7 @@ Flickable {
                     font.pixelSize: 21
                     lineHeight: 24
 
-                    onLinkActivated: {
-                        Qt.openUrlExternally(link);
-                    }
+                    onLinkActivated: (link) => Qt.openUrlExternally(link);
 
                     MouseArea {
                         anchors.fill: parent

--- a/NewsCard.qml
+++ b/NewsCard.qml
@@ -18,8 +18,7 @@
 import QtQuick 2.0
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
-import Fluid.Controls 1.0
-import Fluid.Effects 1.0
+import Fluid.Controls 1.0 as FluidControls
 import QtQuick.Layouts 1.3
 
 Flickable {
@@ -111,7 +110,7 @@ Flickable {
         }
     }
 
-    Card {
+    FluidControls.Card {
         anchors {
             right: parent.right
             top: parent.top
@@ -141,9 +140,9 @@ Flickable {
 
                 width: parent.width
                 height: parent.height
-                spacing: Units.smallSpacing * 2
+                spacing: FluidControls.Units.smallSpacing * 2
 
-                TitleLabel {
+                FluidControls.TitleLabel {
                     id: title
 
                     width: parent.width
@@ -156,7 +155,7 @@ Flickable {
                     font.bold: true
                 }
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: summary
 
                     width: parent.width
@@ -189,9 +188,9 @@ Flickable {
 
                 width: parent.width
                 height: parent.height
-                spacing: Units.smallSpacing * 2
+                spacing: FluidControls.Units.smallSpacing * 2
 
-                BodyLabel {
+                FluidControls.BodyLabel {
                     id: link
 
                     width: parent.width

--- a/UpdateFailed.qml
+++ b/UpdateFailed.qml
@@ -47,9 +47,7 @@ Popup {
         wrapMode: Text.WordWrap
         font.pixelSize: 21
         lineHeight: 24
-        onLinkActivated: {
-            Qt.openUrlExternally(link);
-        }
+        onLinkActivated: (link) => Qt.openUrlExternally(link);
         MouseArea {
             anchors.fill: parent
             acceptedButtons: Qt.NoButton

--- a/main.qml
+++ b/main.qml
@@ -37,11 +37,11 @@ ApplicationWindow {
     Connections {
         target: downloader
         ignoreUnknownSignals: true
-        onStatusMessage: {
+        function onStatusMessage(message) {
             console.log("Download status: " + message);
             infoBar.open(message);
         }
-        onFatalMessage: {
+        function onFatalMessage(message) {
             console.log("Installation failed: " + message);
             errorPopup.errorDetail = message;
             errorPopup.open();

--- a/splash.qml
+++ b/splash.qml
@@ -60,7 +60,7 @@ ApplicationWindow {
     Connections {
         target: splashController
 
-        onUpdateNeeded: {  // game update only
+        function onUpdateNeeded(updateNeeded) {  // game update only
             if (updateNeeded) {
                 showUpdater()
             } else {
@@ -69,7 +69,7 @@ ApplicationWindow {
             }
         }
 
-        onUpdaterUpdate: {
+        function onUpdaterUpdate(version) {
             downloader.startUpdaterUpdate(version);
             updaterUpdateLabel.visible = true;
 
@@ -95,7 +95,7 @@ ApplicationWindow {
         id: splashDownloaderConnections
         target: downloader
 
-        onFatalMessage: {
+        function onFatalMessage(message) {
             updateFailed.errorDetail = message;
             updateFailedWindow.show();
             updateFailed.open();

--- a/splash.qml
+++ b/splash.qml
@@ -19,7 +19,7 @@ import QtQuick 2.0
 import QtQuick.Controls 2.0
 import QtQuick.Controls.Material 2.0
 import Fluid.Controls 1.0 as FluidControls
-import Fluid.Material 1.0
+import Fluid.Material 1.0 as FluidMaterial
 
 ApplicationWindow {
     visible: true
@@ -120,7 +120,7 @@ ApplicationWindow {
         font.pixelSize: 17
     }
 
-    ActionButton {
+    FluidMaterial.ActionButton {
         id: settingsAction
 
         anchors {


### PR DESCRIPTION
Use a single style for Fluid imports to reduce inconsistency and confusion. Use function-style handlers for some QML event handlers to avoid deprecation warnings in Qt 6.