### PR TITLE
Don't use Git in the build system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM docker.io/debian:bullseye-slim
 # updater builds but icons (gear, download, etc.) are mysteriously missing, when built in the
 # Bullseye environment. It may be that not all are necessary.
 # aria2 build requires autoconf, autopoint, gettext
-# updater build requires git
+# git is used for cleaning unwanted files
 RUN apt-get update && apt-get install -y \
     autoconf \
     autopoint \

--- a/deployment.md
+++ b/deployment.md
@@ -5,8 +5,9 @@
 - Torrent URL used to download the latest game version
 
 ## Release process
-1. Create a new Git tag.
-2. Make a Github release with the same name as the tag. Build and upload the files for each platform:
+1. Make a commit updating the version string in `updaterAppVersion()` in `splashcontroller.h`.
+2. Create a new Git tag matching the version string.
+3. Make a Github release with the same name as the tag/version string. Build and upload the files for each platform:
     ### Mac
     1. `rm -rf build/`
     2. Follow the __Build Mac version natively__ instructions in the README.

--- a/main.cpp
+++ b/main.cpp
@@ -159,7 +159,7 @@ CommandLineOptions getCommandLineOptions(const QApplication& app) {
 int main(int argc, char *argv[])
 {
     Sys::initApplicationName();
-    QCoreApplication::setApplicationVersion(GIT_VERSION);
+    QCoreApplication::setApplicationVersion(updaterAppVersion());
     QCoreApplication::setOrganizationDomain("unvanquished.net");
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QApplication app(argc, argv);
@@ -188,7 +188,7 @@ int main(int argc, char *argv[])
         qDebug() << "Will connect to URL:" << options.connectUrl;
     }
 
-    qDebug() << "Git version:" << GIT_VERSION;
+    qDebug() << "Git version:" << updaterAppVersion();
     LogSettings();
     try {
         qDebug() << "Testing exception handling...";

--- a/splashcontroller.cpp
+++ b/splashcontroller.cpp
@@ -95,7 +95,7 @@ void SplashController::autoLaunchOrUpdate()
     }
 
     // If no relaunch action, detect update needed based on versions.json
-    if (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != QString(GIT_VERSION)) {
+    if (!latestUpdaterVersion_.isEmpty() && latestUpdaterVersion_ != updaterAppVersion()) {
         qDebug() << "Updater update to version" << latestUpdaterVersion_ << "required";
         // Remember the URL if we are doing updater update
         QString updaterArgs = "--splashms 1 --internalcommand updateupdater:" + latestUpdaterVersion_;

--- a/splashcontroller.h
+++ b/splashcontroller.h
@@ -24,6 +24,11 @@
 #include "currentversionfetcher.h"
 #include "settings.h"
 
+inline QString updaterAppVersion()
+{
+    return "v0.2.1";
+}
+
 // These are used only on Windows where relaunching is needed for admin (de)elevation.
 enum class RelaunchCommand
 {

--- a/updater.pro
+++ b/updater.pro
@@ -33,8 +33,6 @@ mac {
   SOURCES += win.cpp ExecInExplorer.cpp
 }
 
-GIT_VERSION = $$system(git --git-dir $$PWD/.git --work-tree $$PWD describe --always --tags --abbrev=0)
-DEFINES += GIT_VERSION=\\\"$$GIT_VERSION\\\"
 DEFINES += QUAZIP_BUILD
 DEFINES += QUAZIP_STATIC
 include(quazip/quazip/quazip.pri)


### PR DESCRIPTION
Stop using Git to determine a version number based on tags; just write the version number in the source code. The immediate motivation is that I don't want to have to migrate this stuff to CMake. But anyway I think it's a bad idea for various reasons:
- Doesn't work correctly with incremental rebuilds.
- Unnecessarily adds another program as a build dependency.
- It's possible to fetch a commit without fetching all the tags, meaning you don't have the latest tag.
- The latest tag could be something other than a release. Maybe you fetched from an alternative remote and somebody added a random tag. Maybe we wanted to use a tag for some reason other than a release.