### PR TITLE
Miscellaneous cleanup (Qt6 relevant)

### DIFF
--- a/build-aria.sh
+++ b/build-aria.sh
@@ -10,7 +10,7 @@ if [ ! -f src/aria2api.cc ]; then
 fi
 
 case "$(uname)" in
-	Darwin*)
+        Darwin*)
         export MACOSX_DEPLOYMENT_TARGET=10.13  # To match Qt's target
         export AUTOPOINT=$(brew --prefix gettext)/bin/autopoint
     ;;

--- a/downloadworker.h
+++ b/downloadworker.h
@@ -22,7 +22,6 @@
 #include <atomic>
 #include <QObject>
 #include <QRegularExpression>
-#include <QStandardItemModel>
 
 class DownloadWorker : public QObject, public AriaDownloader::DownloadCallback
 {

--- a/linux.cpp
+++ b/linux.cpp
@@ -32,7 +32,7 @@ namespace Sys {
 
 namespace {
 
-const QString DESKTOP_FILE_NAME = "net.unvanquished.Unvanquished.desktop";
+const char DESKTOP_URI[] = "net.unvanquished.Unvanquished";
 
 // Use QProcess::splitCommand in Qt 5.15+
 QStringList splitArgs(const QString& command) {
@@ -158,14 +158,15 @@ bool installShortcuts()
         qDebug() << "Created directory for desktop files" << desktopDirString;
     }
 
-    QFile desktopFile(":resources/" + DESKTOP_FILE_NAME);
+    QString desktopFileName = QString(DESKTOP_URI) + ".desktop";
+    QFile desktopFile(":resources/" + desktopFileName);
     if (!desktopFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qDebug() << "missing resource" << DESKTOP_FILE_NAME;
+        qDebug() << "missing resource" << desktopFileName;
         return false;
     }
     QString desktopStr = QString(desktopFile.readAll().data()).arg(settings.installPath());
     {
-        QFile outputFile(desktopDir.filePath(DESKTOP_FILE_NAME));
+        QFile outputFile(desktopDir.filePath(desktopFileName));
         if (!outputFile.open(QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate)) {
             qDebug() << "error opening" << outputFile.fileName();
             return false;
@@ -179,7 +180,7 @@ bool installShortcuts()
 
     int ret = QProcess::execute("xdg-mime",
                                 {QString("default"),
-                                 desktopDir.filePath(DESKTOP_FILE_NAME),
+                                 desktopDir.filePath(desktopFileName),
                                  QString("x-scheme-handler/unv")});
     qDebug() << "xdg-mime returned" << ret;
     ret = QProcess::execute("update-desktop-database", {desktopDirString});
@@ -293,9 +294,9 @@ void initApplicationName()
     QCoreApplication::setApplicationName("updater");
 
     // WM_CLASS for X backend
-    qputenv("RESOURCE_NAME", "net.unvanquished.Unvanquished");
+    qputenv("RESOURCE_NAME", DESKTOP_URI);
     // equivalent for Wayland backend
-    QGuiApplication::setDesktopFileName(DESKTOP_FILE_NAME);
+    QGuiApplication::setDesktopFileName(DESKTOP_URI);
 }
 
 // Settings are stored in ~/.config/unvanquished/updater.conf

--- a/main.cpp
+++ b/main.cpp
@@ -22,6 +22,7 @@
 #include <QQmlApplicationEngine>
 #include <QFile>
 #include <QFontDatabase>
+#include <QIcon>
 #include <QQmlContext>
 #include <QDebug>
 #include <QMessageBox>


### PR DESCRIPTION
`Remove an unused #include` turned out to be required for Qt 6. `Linux: remove ".desktop" suffix when setting WM_CLASS` fixes a stderr warning there. 