### PR TITLE
Use -Os when building aria2 and OpenSSL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN curl -LO https://github.com/openssl/openssl/releases/download/openssl-3.6.0/
     curl -L https://github.com/openssl/openssl/releases/download/openssl-3.6.0/openssl-3.6.0.tar.gz.sha256 | sha256sum --check
 RUN tar -xzf openssl-3.6.0.tar.gz
 WORKDIR /build-ssl/openssl-3.6.0
-RUN ./config --prefix=/openssl --openssldir=/dev/null no-shared no-apps no-autoload-config no-capieng no-dso no-dynamic-engine no-engine no-loadereng no-module
+RUN ./config --prefix=/openssl --openssldir=/dev/null no-shared no-apps no-autoload-config no-capieng no-dso no-dynamic-engine no-engine no-loadereng no-module -Os
 RUN make -j`nproc` && make install_sw && rm -rf /build-ssl
 
 ############
@@ -60,7 +60,8 @@ COPY aria2 /updater/aria2
 COPY .git/modules/aria2 /updater/.git/modules/aria2
 COPY build-aria.sh /updater/
 WORKDIR /updater/aria2
-RUN OPENSSL_LIBS='-L/openssl/lib64 -lssl -lcrypto -lpthread -ldl' OPENSSL_CFLAGS='-I /openssl/include' ../build-aria.sh --with-openssl
+RUN OPENSSL_LIBS='-L/openssl/lib64 -lssl -lcrypto -lpthread -ldl' OPENSSL_CFLAGS='-I /openssl/include' \
+    CFLAGS=-Os CXXFLAGS=-Os ../build-aria.sh --with-openssl
 
 #################
 # Build updater #

--- a/Dockerfile.win
+++ b/Dockerfile.win
@@ -51,7 +51,7 @@ COPY .git/modules/aria2 /updater/.git/modules/aria2
 COPY build-aria.sh /updater/
 WORKDIR /updater/aria2
 RUN git clean -dXff
-RUN ../build-aria.sh ARIA2_STATIC=yes --host i686-w64-mingw32
+RUN CFLAGS=-Os CXXFLAGS=-Os ../build-aria.sh ARIA2_STATIC=yes --host i686-w64-mingw32
 
 #################
 # Build updater #

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ brew install autoconf automake libtool pkg-config gettext
 cd aria2
 # If building on M1, target x86 by running in Rosetta: arch -x86_64 ../build-aria.sh
 # (the --target option to configure doesn't seem to have any effect)
-../build-aria.sh
+CFLAGS=-Os CXXFLAGS=-Os ../build-aria.sh
 cd ..
 ```
 


### PR DESCRIPTION
We haven't been using size optimization for these deps. On the Qt 5 updater build it saves 1.0M for OpenSSL and 0.8M for aria2.