### PR TITLE
Fix splash window having a frame on Wayland

### DIFF
--- a/splash.qml
+++ b/splash.qml
@@ -25,7 +25,8 @@ ApplicationWindow {
     id: splash
     width: 745
     height: 228
-    flags: Qt.SplashScreen | Qt.WindowStaysOnTopHint
+    flags: Qt.SplashScreen | Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint
+
 
     Item {
         focus: true


### PR DESCRIPTION
Of course the release builds don't actually support Wayland; this was just annoying when testing against some prebuilt Qt libs that defaulted to Wayland.

Should be well-tested since this was included in the `slipher/qt6-combined` branch that I did most Qt6 testing with.