### PR TITLE
Stop download loop upon download error

### DIFF
--- a/downloadworker.cpp
+++ b/downloadworker.cpp
@@ -95,6 +95,7 @@ void DownloadWorker::onDownloadCallback(aria2::Session* session, aria2::Download
 
         case aria2::EVENT_ON_DOWNLOAD_ERROR:
             qDebug() << "onDownloadCallback event DOWNLOAD_ERROR";
+            running_ = false;
             break;
 
         case aria2::EVENT_ON_DOWNLOAD_PAUSE:


### PR DESCRIPTION
This prevents a lag of up to 1s when closing the application after a download failure.